### PR TITLE
Release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evernote-to-onenote",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evernote-to-onenote",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evernote-to-onenote",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Import Evernote .enex exports into Microsoft OneNote via the Graph API — resumable, scriptable, parallel",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Bumps the npm package to v1.2.0 for the merged non-technical UX and verification refinement wave.

Local verification:
- npm test: 441 tests, 0 failures