### PR TITLE
feat(v1.3.0): add --wizard alias and --reauth flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,31 @@ const MAX_CONCURRENCY = 10;
 
 const VALID_CONFLICT_MODES = ['skip', 'rename', 'overwrite', 'ask'];
 
+
+// v1.3.0: Stored Microsoft session lives in two files next to the project
+// root (matching auth.js paths). --reauth deletes them so the next sign-in
+// starts clean. Returns the list of files actually deleted (empty if none
+// existed).
+function clearStoredAuthFiles() {
+  const projectRoot = path.resolve(__dirname, '..');
+  const candidates = [
+    path.join(projectRoot, '.access-token'),
+    path.join(projectRoot, 'msal-cache.json'),
+  ];
+  const cleared = [];
+  for (const f of candidates) {
+    try {
+      if (fs.existsSync(f)) {
+        fs.unlinkSync(f);
+        cleared.push(path.basename(f));
+      }
+    } catch (err) {
+      console.warn('Could not delete ' + path.basename(f) + ': ' + err.message);
+    }
+  }
+  return cleared;
+}
+
 function checkNodeVersion({ exit = process.exit, stdout = console.log, stderr = console.error } = {}) {
   const [major] = process.versions.node.split('.').map(Number);
   if (major < 18) {
@@ -481,9 +506,31 @@ async function main() {
   if (!checkNodeVersion()) return;
 
   let args = process.argv.slice(2);
-  const setupRequested = args[0] === 'setup';
+  // 'setup' or 'wizard' positional → --guided flag (same code path).
+  const setupRequested = args[0] === 'setup' || args[0] === 'wizard';
   if (setupRequested) {
     args = ['--guided', ...args.slice(1)];
+  }
+
+  // v1.3.0: --reauth clears stored Microsoft session before re-running the
+  // sign-in flow. Useful when the saved token expired or the user wants to
+  // switch accounts. Treated as a superset of --auth.
+  if (args.includes('--reauth')) {
+    const cleared = clearStoredAuthFiles();
+    if (cleared.length > 0) {
+      console.log('Cleared stored sign-in: ' + cleared.join(', '));
+    } else {
+      console.log('No stored sign-in to clear; running --auth flow now.');
+    }
+    await runAuthFlow();
+    console.log('');
+    console.log('─────────────────────────────────────────────');
+    console.log('Re-authentication complete.');
+    console.log('');
+    console.log('Next step — preview your notes before importing:');
+    console.log('  evernote-to-onenote --batch <folder-with-enex-files> --dry-run');
+    console.log('');
+    process.exit(0);
   }
 
   if (args.includes('--auth')) {
@@ -542,6 +589,8 @@ async function main() {
       '',
       'Usage:',
       '  evernote-to-onenote --auth                     Sign in to Microsoft (once)',
+      '  evernote-to-onenote --reauth                   Re-sign-in (clears the saved session first)',
+      '  evernote-to-onenote wizard                     Beginner setup helper (alias for `setup`)',
       '  evernote-to-onenote --batch <dir> --dry-run    Preview (no data sent to OneNote)',
       '  evernote-to-onenote --batch <dir>              Run the import',
       '  evernote-to-onenote --verify                   Check import completed correctly',
@@ -551,6 +600,8 @@ async function main() {
       '',
       'All options:',
       '  --guided               Step-by-step prompts; starts with a safe preview',
+      '  --wizard               Same as --guided (preferred name)',
+      '  --reauth               Clear the saved Microsoft sign-in and re-authenticate',
       '  --no-interactive       Never open prompts; print next-step usage instead',
       '  --auth                 Sign in to Microsoft and save your session, then exit',
       '  --batch <dir>          Import all .enex files in a folder',
@@ -586,7 +637,8 @@ async function main() {
   const yearSections = args.includes('--year-sections');
   const verify = args.includes('--verify');
   const noInteractive = args.includes('--no-interactive');
-  const guidedRequested = args.includes('--guided');
+  // v1.3.0: --wizard is the recommended name; --guided kept for back-compat.
+  const guidedRequested = args.includes('--guided') || args.includes('--wizard');
 
   // Guided mode: --guided flag OR no args on a TTY -> interactive prompts.
   let interactiveFiles = null;
@@ -969,6 +1021,7 @@ if (require.main === module) {
 
 module.exports = {
   importNotes,
+  clearStoredAuthFiles,  // v1.3.0 — exposed for unit tests
   runVerify,
   checkNodeVersion,
   hasSavedMicrosoftSession,

--- a/tests/wizard.test.js
+++ b/tests/wizard.test.js
@@ -1,0 +1,145 @@
+'use strict';
+/**
+ * v1.3.0 wizard + reauth tests.
+ *
+ * Tests the new `--wizard` flag (alias for `--guided`), the `wizard`
+ * positional (alias for `setup`), and the `--reauth` flow that clears
+ * stored Microsoft sign-in files before re-running auth.
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const CLI = path.join(__dirname, '..', 'src', 'index.js');
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+function run(args, opts = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ONENOTE_ACCESS_TOKEN: '', MSAL_NO_INTERACTIVE: '1', ...(opts.env || {}) },
+    timeout: 15000,
+    cwd: opts.cwd,
+  });
+}
+
+describe('CLI — --help mentions --wizard and --reauth (v1.3.0)', () => {
+  test('--help text mentions --wizard as preferred guided-mode name', () => {
+    const { stdout, status } = run(['--help']);
+    assert.equal(status, 0);
+    assert.match(stdout, /--wizard\b/);
+  });
+
+  test('--help text mentions --reauth', () => {
+    const { stdout } = run(['--help']);
+    assert.match(stdout, /--reauth\b/);
+  });
+
+  test('--help text mentions `wizard` positional alias', () => {
+    const { stdout } = run(['--help']);
+    assert.match(stdout, /\bwizard\b/);
+  });
+});
+
+describe('CLI — --wizard flag dispatch', () => {
+  test('--wizard flag is recognised (does not error as unknown option)', () => {
+    // --no-interactive bypasses the interactive prompt path; we just check
+    // the program doesn't crash on the unknown flag.
+    const { stderr, status } = run(['--wizard', '--no-interactive']);
+    // Either exits 0 (info dump) or shows usage hints on stderr; in neither
+    // case should it complain about an unknown argument.
+    assert.doesNotMatch(stderr, /unknown.*--wizard/i);
+    assert.doesNotMatch(stderr, /unrecognized.*--wizard/i);
+    assert.ok([0, 1].includes(status), `expected exit 0 or 1, got ${status}`);
+  });
+
+  test('`wizard` positional treated like `setup`', () => {
+    const { stderr, status } = run(['wizard', '--no-interactive']);
+    // Same surface as `setup` — should not complain about an unknown command.
+    assert.doesNotMatch(stderr, /unknown command/i);
+    assert.doesNotMatch(stderr, /unrecognized.*wizard/i);
+    assert.ok([0, 1].includes(status), `expected exit 0 or 1, got ${status}`);
+  });
+});
+
+describe('clearStoredAuthFiles helper', () => {
+  // We test the exported helper directly — running --reauth end-to-end would
+  // touch the real auth file paths next to the project root and affect
+  // developer environments. The helper takes no args, so we manipulate the
+  // actual paths in a controlled way: snapshot existing files (if any),
+  // create dummies, run, assert, restore.
+
+  const TARGET_FILES = [
+    path.join(PROJECT_ROOT, '.access-token'),
+    path.join(PROJECT_ROOT, 'msal-cache.json'),
+  ];
+
+  function snapshotAndClear() {
+    const snapshot = {};
+    for (const f of TARGET_FILES) {
+      if (fs.existsSync(f)) {
+        snapshot[f] = fs.readFileSync(f);
+        fs.unlinkSync(f);
+      }
+    }
+    return snapshot;
+  }
+
+  function restore(snapshot) {
+    for (const [f, data] of Object.entries(snapshot)) {
+      fs.writeFileSync(f, data);
+    }
+  }
+
+  test('deletes both stored auth files when both exist', () => {
+    const snapshot = snapshotAndClear();
+    try {
+      // Set up dummy files
+      for (const f of TARGET_FILES) {
+        fs.writeFileSync(f, 'dummy');
+      }
+      const { clearStoredAuthFiles } = require('../src/index.js');
+      const cleared = clearStoredAuthFiles();
+      assert.deepEqual(cleared.sort(), ['.access-token', 'msal-cache.json']);
+      for (const f of TARGET_FILES) {
+        assert.equal(fs.existsSync(f), false, `${path.basename(f)} should be deleted`);
+      }
+    } finally {
+      // Belt-and-braces: clean up any dummies we left behind, then restore.
+      for (const f of TARGET_FILES) {
+        if (fs.existsSync(f)) fs.unlinkSync(f);
+      }
+      restore(snapshot);
+    }
+  });
+
+  test('returns empty list when no stored auth files exist', () => {
+    const snapshot = snapshotAndClear();
+    try {
+      const { clearStoredAuthFiles } = require('../src/index.js');
+      const cleared = clearStoredAuthFiles();
+      assert.deepEqual(cleared, []);
+    } finally {
+      restore(snapshot);
+    }
+  });
+
+  test('returns only the files that actually existed', () => {
+    const snapshot = snapshotAndClear();
+    try {
+      // Create only one of the two
+      fs.writeFileSync(TARGET_FILES[0], 'dummy');
+      const { clearStoredAuthFiles } = require('../src/index.js');
+      const cleared = clearStoredAuthFiles();
+      assert.deepEqual(cleared, ['.access-token']);
+      assert.equal(fs.existsSync(TARGET_FILES[0]), false);
+    } finally {
+      for (const f of TARGET_FILES) {
+        if (fs.existsSync(f)) fs.unlinkSync(f);
+      }
+      restore(snapshot);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two small additive CLI surfaces. The existing public guided-setup flow (`evernote-to-onenote setup` / `--guided` / no-args-on-TTY) is the right shape and stays unchanged; this PR adds the names users naturally try and a flag for the common 'my saved sign-in expired' case.

## What's new

| Surface | Behaviour |
|---|---|
| `--wizard` | Alias for `--guided`. Both names accepted; `--guided` stays for back-compat. |
| `wizard` (positional) | Alias for `setup`. Same code path. |
| `--reauth` | Clears the stored Microsoft session files (`.access-token` + `msal-cache.json`) and re-runs the `--auth` flow. Reports which files were cleared. |
| `--help` text | Mentions `--wizard` as the preferred guided-mode name and `--reauth` as an option. |

## Why `--reauth`

The most common 'something's wrong' state is an expired or corrupted saved sign-in. Today the user has to manually delete `.access-token` and `msal-cache.json` next to the project root before re-running `--auth`. `--reauth` does both in one command and tells the user what was cleared.

## Tests

- **449 pass / 0 fail** (was 441 baseline, 7 integration tests still skipped)
- +8 new tests covering: `--wizard` flag recognition, `wizard` positional, and `clearStoredAuthFiles` helper across three states (both files exist, neither, only one)

## Backwards compatibility

- Every v1.2.4 flag and positional (`setup`, `--guided`, `--auth`, `--doctor`, `--batch`, etc.) works identically
- No new dependencies
- No public API changes other than the new `clearStoredAuthFiles` export (test-only)

## Reference

Reference TypeScript implementation: `typescript-rewrite-spike-2026-05-03` branch. Full release plan in the JMS Dev Lab parent repo.

PR2 (ENML edge-case hardening) is at #12. PR3 (resume hardening for partial OneDrive uploads) is queued — it requires a `progress.json` schema migration which makes it bigger than this PR or PR2.