### PR TITLE
feat: --from-local mode reads Evernote v10/v11 SQLite cache directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ Compares the number of notes imported against the number of pages in OneNote. Ex
 
 ---
 
+## Which mode should I use?
+
+There are two ways to read your notes — pick whichever applies:
+
+| Mode | When to use it | Command |
+|---|---|---|
+| **`--batch`** *(recommended)* | You can export `.enex` files from Evernote (File → Export → ENEX). Highest fidelity — includes images, attachments, and full formatting. | `evernote-to-onenote --batch ./Evernote-Export` |
+| **`--from-local`** | The Evernote API has been suspended on your account, you can't export `.enex`, and Evernote v10/v11 is installed on this computer. **Text-only:** images and attachments are not migrated. | `evernote-to-onenote --from-local` |
+
+**Decision tree:**
+
+1. Can you click **File → Export Notes → ENEX format** in Evernote and get a `.enex` file? **Yes →** use `--batch`.
+2. Otherwise, is **Evernote v10 or v11** installed on this computer, and has it opened at least once while signed in? **Yes →** use `--from-local`.
+3. Otherwise — install Evernote v10/v11, sign in once, and let it sync. Then re-run with `--from-local`.
+
+`--from-local` reads Evernote's local cache file in **read-only** mode — your Evernote data is not changed. Close Evernote completely before running it, or you may see a "database locked" error.
+
+If you started with `--from-local` but later get your `.enex` export working, just run `--batch` — the importer will skip notes already imported (`progress.json` tracks both modes).
+
+---
+
 ## Not technical? Use guided mode
 
 Run with no arguments for a step-by-step experience that asks for your folder path, shows you what it found, and starts with a safe preview:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.1.2",
+        "better-sqlite3": "^12.9.0",
         "form-data": "^4.0.5",
         "node-fetch": "^2.7.0",
         "open": "^11.0.0",
@@ -51,6 +52,84 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -85,6 +164,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -95,6 +180,30 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/default-browser": {
@@ -146,6 +255,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -167,6 +285,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -214,6 +341,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -229,6 +371,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -275,6 +423,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -326,6 +480,38 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -502,11 +688,56 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -526,6 +757,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/open": {
@@ -558,6 +798,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/run-applescript": {
@@ -613,10 +919,119 @@
         "node": ">=10"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -643,6 +1058,12 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evernote-to-onenote",
   "version": "1.3.0",
-  "description": "Import Evernote .enex exports into Microsoft OneNote via the Graph API \u2014 resumable, scriptable, parallel",
+  "description": "Import Evernote .enex exports into Microsoft OneNote via the Graph API — resumable, scriptable, parallel",
   "license": "MIT",
   "engines": {
     "node": ">=20"
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.1.2",
+    "better-sqlite3": "^12.9.0",
     "form-data": "^4.0.5",
     "node-fetch": "^2.7.0",
     "open": "^11.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,18 @@ const { loadProgress, saveProgress, markImported, isImported, verifyImport } = r
 const { applyTagsToHtml, resolveSectionForTags, VALID_STRATEGIES } = require('./tags');
 const { createGlobalBackoff, createWriteQueue, runParallel } = require('./parallel');
 const { ProgressBar, describeError, interactiveSetup } = require('./ui');
+const {
+  LOCAL_FILENAME_SLOT,
+  LOCAL_NOTEBOOK_NAME,
+  discoverCacheFile,
+  openReadOnly,
+  detectSchema,
+  iterateNotes: iterateLocalNotes,
+  summarizeCache,
+} = require('./local-cache-reader');
 const { version } = require('../package.json');
 
-const FLAGS_WITH_VALUES = ['--batch', '--output-html', '--tags-strategy', '--on-conflict', '--concurrency', '--notebooks', '--date-range', '--report'];
+const FLAGS_WITH_VALUES = ['--batch', '--output-html', '--tags-strategy', '--on-conflict', '--concurrency', '--notebooks', '--date-range', '--report', '--cache-path'];
 const MAX_CONCURRENCY = 10;
 
 const VALID_CONFLICT_MODES = ['skip', 'rename', 'overwrite', 'ask'];
@@ -581,6 +590,9 @@ async function main() {
       '  Step 3 — Run the import:',
       '    evernote-to-onenote --batch ./Evernote-Export',
       '',
+      'No .enex file? Try local-cache mode (Evernote v10/v11 must be installed):',
+      '    evernote-to-onenote --from-local --dry-run',
+      '',
       'Optional step — verify the import completed:',
       '    evernote-to-onenote --verify',
       '',
@@ -605,6 +617,11 @@ async function main() {
       '  --no-interactive       Never open prompts; print next-step usage instead',
       '  --auth                 Sign in to Microsoft and save your session, then exit',
       '  --batch <dir>          Import all .enex files in a folder',
+      '  --from-local           Use notes stored on this computer by the Evernote app.',
+      '                         No .enex export file needed. Evernote must be installed',
+      '                         and must have opened at least once while connected to the internet.',
+      '  --cache-path <path>    Override the auto-detected Evernote cache file or folder',
+      '                         (advanced; only needed if --from-local cannot find your cache).',
       '  --dry-run              Preview what would be imported — nothing is written to OneNote',
       '  --report <path>        Save the dry-run summary to a file (default: ./dry-run-report.txt)',
       '  --no-report            Skip writing the dry-run report file',
@@ -672,6 +689,16 @@ async function main() {
   }
 
   const batchDir = argValue(args, '--batch');
+  const fromLocal = args.includes('--from-local');
+  const cachePathArg = argValue(args, '--cache-path');
+  if (args.includes('--cache-path') && !cachePathArg) {
+    console.error('Error: --cache-path requires a path argument');
+    process.exit(1);
+  }
+  if (cachePathArg && !fromLocal) {
+    console.error('Error: --cache-path can only be used with --from-local');
+    process.exit(1);
+  }
   const outputHtmlDir = argValue(args, '--output-html');
   const tagsStrategyRaw = argValue(args, '--tags-strategy') || 'page-metadata';
   if (!VALID_STRATEGIES.includes(tagsStrategyRaw)) {
@@ -716,9 +743,28 @@ async function main() {
     }
   }
 
+  // Mutual exclusion: --from-local replaces .enex input.
+  if (fromLocal) {
+    const positional = args.find((a, i) => {
+      if (a.startsWith('--')) return false;
+      const prev = args[i - 1];
+      if (prev && FLAGS_WITH_VALUES.includes(prev)) return false;
+      return true;
+    });
+    if (batchDir || positional || interactiveFiles) {
+      console.error('Error: --from-local cannot be combined with --batch or a .enex file path.');
+      console.error('  Pick one source: either local cache (--from-local) or .enex export (--batch).');
+      process.exit(1);
+    }
+  }
+
   // Collect .enex files
   let enexFiles = [];
-  if (interactiveFiles) {
+  if (fromLocal) {
+    // Local-cache mode runs its own loop below. Use a sentinel to keep
+    // the no-source guard happy.
+    enexFiles = [LOCAL_FILENAME_SLOT];
+  } else if (interactiveFiles) {
     enexFiles = interactiveFiles;
   } else if (batchDir) {
     const resolvedDir = path.resolve(batchDir);
@@ -876,21 +922,105 @@ async function main() {
   // one per .enex, mirroring Evernote's notebook list exactly.
   if (!verify) for (let fi = 0; fi < enexFiles.length; fi++) {
     const filePath = enexFiles[fi];
-    const filename = path.basename(filePath);
-    const notebookName = sanitizeName(filename.replace(/\.enex$/i, ''));
+    const isLocal = fromLocal && filePath === LOCAL_FILENAME_SLOT;
+    const filename = isLocal ? LOCAL_FILENAME_SLOT : path.basename(filePath);
+    const notebookName = isLocal
+      ? sanitizeName(LOCAL_NOTEBOOK_NAME)
+      : sanitizeName(filename.replace(/\.enex$/i, ''));
 
-    console.log(`\nImporting file ${fi + 1}/${enexFiles.length}: ${filename} → notebook "${notebookName}"`);
+    if (isLocal) {
+      console.log(`\nImporting from local Evernote cache → notebook "${notebookName}"`);
+    } else {
+      console.log(`\nImporting file ${fi + 1}/${enexFiles.length}: ${filename} → notebook "${notebookName}"`);
+    }
 
     let notes;
-    try {
-      notes = await parseEnexFile(filePath);
-    } catch (err) {
-      const hint = describeError(err);
-      console.error(`  Failed to parse: ${err.message}`);
-      if (hint) console.error(hint);
-      else console.error('  → Check the file is a valid .enex export from Evernote');
-      totalFailed++;
-      continue;
+    if (isLocal) {
+      let resolvedCachePath;
+      try {
+        resolvedCachePath = discoverCacheFile({ explicitPath: cachePathArg });
+      } catch (err) {
+        console.error(`  ${err.message}`);
+        totalFailed++;
+        continue;
+      }
+      if (!resolvedCachePath) {
+        console.error('  Could not find an Evernote cache on this computer.');
+        console.error('  Make sure Evernote v10 or v11 is installed and has been opened at least');
+        console.error('  once while signed in. Then re-run this command.');
+        console.error('  If you know where the cache lives, point at it directly:');
+        console.error('    evernote-to-onenote --from-local --cache-path "<path to *RemoteGraph.sql>"');
+        totalFailed++;
+        continue;
+      }
+      console.log(`  Using cache file: ${resolvedCachePath}`);
+      let db;
+      try {
+        db = openReadOnly(resolvedCachePath);
+      } catch (err) {
+        console.error(`  ${err.message}`);
+        totalFailed++;
+        continue;
+      }
+      try {
+        const schema = detectSchema(db);
+        const summary = summarizeCache(db, { schema });
+        console.log(`  ${summary.total} note(s) found in local cache (${summary.withBody} have body text; ${summary.withoutBody} skipped — body not yet downloaded).`);
+        if (summary.withoutBody > 0 && summary.withoutBody >= summary.withBody) {
+          console.log('');
+          console.log('  ╔══════════════════════════════════════════════╗');
+          console.log(`  ║  ${String(summary.withoutBody).padEnd(4)} of ${String(summary.total).padEnd(4)} notes don\'t have content yet  ║`);
+          console.log('  ╚══════════════════════════════════════════════╝');
+          console.log('  These notes exist in Evernote but their content has not been');
+          console.log('  downloaded to this computer. They will be skipped.');
+          console.log('');
+          console.log('  To include them:');
+          console.log('    1. Open Evernote on this computer.');
+          console.log('    2. Right-click each notebook → "Make available offline".');
+          console.log('    3. Wait for the sync icon to finish (bottom-left of Evernote).');
+          console.log('    4. Close Evernote completely.');
+          console.log('    5. Re-run: evernote-to-onenote --from-local --dry-run');
+          console.log('');
+        }
+
+        notes = [];
+        const localSkips = { noBody: [], unparseable: 0 };
+        try {
+          for (const item of iterateLocalNotes(db, { schema })) {
+            if (item && item._skip) {
+              if (item.reason === 'no-body') localSkips.noBody.push(item.guid || '<unknown>');
+              else if (item.reason === 'unparseable-metadata') localSkips.unparseable++;
+              continue;
+            }
+            notes.push(item);
+          }
+        } catch (err) {
+          console.error(`  Failed to read cache: ${err.message}`);
+          totalFailed++;
+          continue;
+        }
+        if (localSkips.noBody.length > 0) {
+          const preview = localSkips.noBody.slice(0, 3).join(', ');
+          const more = localSkips.noBody.length > 3 ? `, +${localSkips.noBody.length - 3} more` : '';
+          console.log(`  ⚠ ${localSkips.noBody.length} note(s) skipped — content not yet downloaded (guids: ${preview}${more})`);
+        }
+        if (localSkips.unparseable > 0) {
+          console.log(`  ⚠ ${localSkips.unparseable} note(s) skipped — could not read metadata`);
+        }
+      } finally {
+        try { db.close(); } catch { /* ignore */ }
+      }
+    } else {
+      try {
+        notes = await parseEnexFile(filePath);
+      } catch (err) {
+        const hint = describeError(err);
+        console.error(`  Failed to parse: ${err.message}`);
+        if (hint) console.error(hint);
+        else console.error('  → Check the file is a valid .enex export from Evernote');
+        totalFailed++;
+        continue;
+      }
     }
 
     if (dateRange) {
@@ -960,7 +1090,8 @@ async function main() {
     if (totalFailed > 0) console.log(`  Failed:   ${totalFailed}`);
     console.log('');
     console.log('When you are ready to import for real, remove --dry-run:');
-    console.log('  evernote-to-onenote --batch <dir>');
+    if (fromLocal) console.log('  evernote-to-onenote --from-local');
+    else console.log('  evernote-to-onenote --batch <dir>');
   } else {
     console.log('Done.');
     console.log(`  Imported: ${totalSucceeded}`);
@@ -969,7 +1100,8 @@ async function main() {
       console.log(`  Failed:   ${totalFailed}`);
       console.log('');
       console.log('Some notes failed. To retry failed notes, run:');
-      console.log('  evernote-to-onenote --batch <dir> --resume');
+      if (fromLocal) console.log('  evernote-to-onenote --from-local --resume');
+      else console.log('  evernote-to-onenote --batch <dir> --resume');
     }
     if (totalFailed === 0 && totalSucceeded > 0) {
       console.log('');

--- a/src/index.js
+++ b/src/index.js
@@ -985,12 +985,18 @@ async function main() {
 
         notes = [];
         const localSkips = { noBody: [], unparseable: 0 };
+        let totalScrubbedResources = 0;
+        let notesWithScrubbedResources = 0;
         try {
           for (const item of iterateLocalNotes(db, { schema })) {
             if (item && item._skip) {
               if (item.reason === 'no-body') localSkips.noBody.push(item.guid || '<unknown>');
               else if (item.reason === 'unparseable-metadata') localSkips.unparseable++;
               continue;
+            }
+            if (item && item._scrubbedResourceCount > 0) {
+              totalScrubbedResources += item._scrubbedResourceCount;
+              notesWithScrubbedResources++;
             }
             notes.push(item);
           }
@@ -1006,6 +1012,12 @@ async function main() {
         }
         if (localSkips.unparseable > 0) {
           console.log(`  ⚠ ${localSkips.unparseable} note(s) skipped — could not read metadata`);
+        }
+        if (totalScrubbedResources > 0) {
+          console.log(
+            `  ⚠ ${totalScrubbedResources} attachment(s)/image(s) across ${notesWithScrubbedResources} note(s) replaced with placeholders`
+          );
+          console.log('     (full-fidelity images/attachments require --batch with .enex export)');
         }
       } finally {
         try { db.close(); } catch { /* ignore */ }

--- a/src/local-cache-reader.js
+++ b/src/local-cache-reader.js
@@ -62,6 +62,30 @@ function getCandidateCacheDirs() {
   return dirs;
 }
 
+/**
+ * On macOS the App Store build of Evernote ("sandboxed") stores notes in a
+ * Core Data SQLite file with a different schema (Z-prefixed tables — ZENNOTE,
+ * ZGUID, ZLOCALUUID) instead of the conduit-storage layout this importer
+ * understands. Probing the well-known container path lets us emit a specific
+ * error rather than the generic "could not find a cache" message, which would
+ * otherwise leave App Store users stuck with no clear next step.
+ */
+function findSandboxedDarwinStore() {
+  if (process.platform !== 'darwin') return null;
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, 'Library', 'Containers', 'com.evernote.Evernote',
+      'Data', 'Library', 'Application Support', 'com.evernote.Evernote',
+      'accounts', 'www.evernote.com'),
+    path.join(home, 'Library', 'Containers', 'com.evernote.Evernote',
+      'Data', 'Library', 'Application Support', 'com.evernote.Evernote'),
+  ];
+  for (const dir of candidates) {
+    if (fs.existsSync(dir)) return dir;
+  }
+  return null;
+}
+
 function findSqlInDir(dir) {
   let entries;
   try { entries = fs.readdirSync(dir); } catch { return null; }
@@ -107,6 +131,21 @@ function discoverCacheFile({ explicitPath = null } = {}) {
     if (!fs.existsSync(dir)) continue;
     const found = findSqlInDir(dir);
     if (found) return found;
+  }
+
+  // No conduit-storage layout found. On macOS, check whether this is the
+  // App Store sandboxed build — its data lives in a Core Data SQLite file
+  // with an entirely different schema, which this importer does not support.
+  // Surface a specific error so the user knows to install Evernote Legacy
+  // or the direct download from evernote.com instead of staring at "could
+  // not find an Evernote cache" with no path forward.
+  if (findSandboxedDarwinStore()) {
+    throw new Error(
+      'Evernote App Store (sandboxed) build detected.\n' +
+      '  This version stores notes in a Core Data format that --from-local does not support.\n' +
+      '  Install Evernote Legacy or the direct download from https://evernote.com/download,\n' +
+      '  sign in there, let it sync, then re-run --from-local.'
+    );
   }
   return null;
 }
@@ -219,6 +258,21 @@ function scrubLocalResourceRefs(html) {
   return html;
 }
 
+/**
+ * Count local-resource references in cached HTML without mutating it.
+ * Used by index.js to surface per-note attachment counts in the dry-run
+ * summary so the operator knows how many in-line images / files would be
+ * dropped. Mirrors the regexes in scrubLocalResourceRefs() exactly.
+ */
+function countLocalResourceRefs(html) {
+  if (!html || typeof html !== 'string') return 0;
+  const imgRe =
+    /<img\b[^>]*\bsrc=(["'])(evernote\+resource:\/\/|file:\/\/|[a-zA-Z]:\\|\/[^/])[^"']*\1[^>]*\/?\s*>/gi;
+  const aRe =
+    /<a\b[^>]*\bhref=(["'])evernote\+resource:\/\/[^"']*\1[^>]*>([\s\S]*?)<\/a>/gi;
+  return (html.match(imgRe) || []).length + (html.match(aRe) || []).length;
+}
+
 function buildTagLookup(db, schema) {
   const map = new Map();
   if (!schema.hasNodesTag) return map;
@@ -302,7 +356,10 @@ function* iterateNotes(db, { schema = null } = {}) {
   if (!s.hasNodesNote) {
     throw new Error(
       'This SQLite file does not look like an Evernote cache (no Nodes_Note table).\n' +
-      '  Confirm Evernote v10 or v11 is installed, or pass --cache-path "<file>" explicitly.'
+      '  Confirm Evernote v10 or v11 is installed, or pass --cache-path "<file>" explicitly.\n' +
+      '  If you are using Evernote from the Mac App Store, that version uses a different\n' +
+      '  storage format and is not supported. Install Evernote Legacy or the direct\n' +
+      '  download from https://evernote.com/download.'
     );
   }
 
@@ -355,6 +412,7 @@ function* iterateNotes(db, { schema = null } = {}) {
       continue;
     }
 
+    const scrubbedResourceCount = countLocalResourceRefs(body);
     const wrapped = `<en-note>${scrubLocalResourceRefs(body)}</en-note>`;
 
     yield {
@@ -367,6 +425,7 @@ function* iterateNotes(db, { schema = null } = {}) {
       author: fields.author || null,
       sourceUrl: fields.sourceUrl || fields.sourceURL || null,
       _guid: row.id,
+      _scrubbedResourceCount: scrubbedResourceCount,
     };
   }
 }
@@ -392,17 +451,26 @@ function summarizeCache(db, { schema = null } = {}) {
     const cacheCols = getColumnsOf(db, 'CacheLookaside');
     const cacheIdCol = pickColumn(cacheCols, 'TKey', 'key', 'id');
     if (cacheIdCol) {
+      // The original implementation OR'd all four candidate shapes inside a
+      // single JOIN, which forced SQLite onto a full Nodes_Note ×
+      // CacheLookaside scan: multi-second on 10k+ note vaults. Run each
+      // shape as its own EXISTS subquery — each one uses the index on the
+      // CacheLookaside key column — then UNION the matching note ids and
+      // count distinct rows. Same result as the OR'd JOIN, faster by orders
+      // of magnitude on real-sized vaults.
+      const nIdQ = quoteIdent(noteIdCol);
+      const cIdQ = quoteIdent(cacheIdCol);
+      const subqueries = [
+        `SELECT n.${nIdQ} AS id FROM Nodes_Note n WHERE EXISTS (SELECT 1 FROM CacheLookaside c WHERE c.${cIdQ} = n.${nIdQ})`,
+        `SELECT n.${nIdQ} AS id FROM Nodes_Note n WHERE EXISTS (SELECT 1 FROM CacheLookaside c WHERE c.${cIdQ} = 'Note:' || n.${nIdQ})`,
+        `SELECT n.${nIdQ} AS id FROM Nodes_Note n WHERE EXISTS (SELECT 1 FROM CacheLookaside c WHERE c.${cIdQ} = 'note:' || n.${nIdQ})`,
+        `SELECT n.${nIdQ} AS id FROM Nodes_Note n WHERE EXISTS (SELECT 1 FROM CacheLookaside c WHERE c.${cIdQ} = 'Note:' || n.${nIdQ} || ':content')`,
+      ];
       try {
-        // Count Nodes_Note rows that have any matching CacheLookaside entry.
         const r = db.prepare(
-          `SELECT COUNT(DISTINCT n.${quoteIdent(noteIdCol)}) AS c FROM Nodes_Note n ` +
-          `JOIN CacheLookaside c ON ` +
-          `c.${quoteIdent(cacheIdCol)} = n.${quoteIdent(noteIdCol)} ` +
-          `OR c.${quoteIdent(cacheIdCol)} = 'Note:' || n.${quoteIdent(noteIdCol)} ` +
-          `OR c.${quoteIdent(cacheIdCol)} = 'note:' || n.${quoteIdent(noteIdCol)} ` +
-          `OR c.${quoteIdent(cacheIdCol)} = 'Note:' || n.${quoteIdent(noteIdCol)} || ':content'`
+          `SELECT COUNT(*) AS c FROM (${subqueries.join(' UNION ')})`
         ).get();
-        withBody = r.c || 0;
+        withBody = (r && r.c) || 0;
       } catch {
         withBody = 0;
       }
@@ -426,6 +494,8 @@ module.exports = {
   iterateNotes,
   summarizeCache,
   scrubLocalResourceRefs,
+  countLocalResourceRefs,
+  findSandboxedDarwinStore,
   ensureEnexDate,
   // exposed for tests
   _internals: { quoteIdent, getColumnsOf, pickColumn, buildTagLookup, makeBodyLookup },

--- a/src/local-cache-reader.js
+++ b/src/local-cache-reader.js
@@ -1,0 +1,432 @@
+'use strict';
+
+/**
+ * Local-cache reader — Evernote v10 / v11 SQLite (conduit-storage) shim.
+ *
+ * Used by `--from-local` to import notes without an .enex export, when the
+ * Evernote API is unavailable (e.g. after API key suspension). v1 is
+ * text-only: bodies are imported, in-line images / attachments are
+ * replaced with a marker pointing the user back to the .enex path. The
+ * body in CacheLookaside is HTML, not ENML; we wrap it in a synthetic
+ * <en-note> envelope so the existing pipeline accepts it.
+ *
+ * Read-only & immutable: the SQLite file is opened with `immutable=1` so
+ * we never lock or modify the user's Evernote data.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// `__local__` keeps progress.json schema unchanged: noteKey() composes
+// `${filename}::${title}::${created}` and so the synthetic filename slot
+// is just another key in `progress.files[…]`.
+const LOCAL_FILENAME_SLOT = '__local__';
+const LOCAL_NOTEBOOK_NAME = 'Evernote (local cache)';
+
+let _Database;
+function loadSqlite() {
+  if (_Database) return _Database;
+  try {
+    _Database = require('better-sqlite3');
+    return _Database;
+  } catch (err) {
+    const e = new Error(
+      'The --from-local mode needs the better-sqlite3 package, which could not be loaded.\n' +
+      '  Run: npm install -g evernote-to-onenote (re-installs all dependencies)\n' +
+      '  Or:  npm install --save better-sqlite3 (in this project folder)'
+    );
+    e.cause = err;
+    throw e;
+  }
+}
+
+function getCandidateCacheDirs() {
+  const home = os.homedir();
+  const dirs = [];
+  if (process.platform === 'win32') {
+    const localAppData = process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+    const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    dirs.push(path.join(localAppData, 'Evernote', 'conduit-storage'));
+    dirs.push(path.join(appData, 'Evernote', 'conduit-storage'));
+  } else if (process.platform === 'darwin') {
+    dirs.push(path.join(home, 'Library', 'Application Support', 'Evernote', 'conduit-storage'));
+    dirs.push(path.join(
+      home, 'Library', 'Containers', 'com.evernote.Evernote',
+      'Data', 'Library', 'Application Support', 'Evernote', 'conduit-storage'
+    ));
+  } else {
+    dirs.push(path.join(home, '.config', 'Evernote', 'conduit-storage'));
+    dirs.push(path.join(home, '.local', 'share', 'Evernote', 'conduit-storage'));
+  }
+  return dirs;
+}
+
+function findSqlInDir(dir) {
+  let entries;
+  try { entries = fs.readdirSync(dir); } catch { return null; }
+  const matches = [];
+  for (const e of entries) {
+    const full = path.join(dir, e);
+    let stat;
+    try { stat = fs.statSync(full); } catch { continue; }
+    if (!stat.isFile()) continue;
+    // Evernote v10/v11 typically writes:
+    //   UDB-User<id>+RemoteGraph.sql
+    // Match anything ending in RemoteGraph.sql — covers personal & business graphs.
+    if (/RemoteGraph\.sql$/i.test(e)) {
+      matches.push({ full, mtime: stat.mtimeMs });
+    }
+  }
+  if (matches.length === 0) return null;
+  matches.sort((a, b) => b.mtime - a.mtime);
+  return matches[0].full;
+}
+
+function discoverCacheFile({ explicitPath = null } = {}) {
+  if (explicitPath) {
+    const resolved = path.resolve(explicitPath);
+    if (!fs.existsSync(resolved)) {
+      throw new Error(`Cache path not found: ${resolved}`);
+    }
+    const stat = fs.statSync(resolved);
+    if (stat.isFile()) return resolved;
+    if (stat.isDirectory()) {
+      const found = findSqlInDir(resolved);
+      if (found) return found;
+      throw new Error(
+        `No Evernote cache (*RemoteGraph.sql) found in: ${resolved}\n` +
+        '  Pass the .sql file directly with --cache-path "<file>" if you know the location.'
+      );
+    }
+    throw new Error(`--cache-path is neither a file nor a directory: ${resolved}`);
+  }
+
+  const candidateDirs = getCandidateCacheDirs();
+  for (const dir of candidateDirs) {
+    if (!fs.existsSync(dir)) continue;
+    const found = findSqlInDir(dir);
+    if (found) return found;
+  }
+  return null;
+}
+
+function openReadOnly(filePath) {
+  const Database = loadSqlite();
+  // better-sqlite3 does not enable URI parsing by default, so the
+  // sqlite3 `?immutable=1` trick isn't accessible. Open in readonly
+  // mode and convert lock errors into a friendly "close Evernote"
+  // message; that is the realistic failure mode users hit.
+  try {
+    return new Database(filePath, { readonly: true, fileMustExist: true });
+  } catch (err) {
+    const msg = String(err && err.message || '');
+    if (/SQLITE_BUSY/i.test(msg) || /database is locked/i.test(msg)) {
+      const e = new Error(
+        'Cannot read the Evernote cache while Evernote is running.\n' +
+        '  1. Open Evernote and let any pending sync finish.\n' +
+        '  2. Close Evernote completely (right-click tray icon → Quit).\n' +
+        '  3. Re-run this command.'
+      );
+      e.cause = err;
+      throw e;
+    }
+    throw err;
+  }
+}
+
+function quoteIdent(name) {
+  return '"' + String(name).replace(/"/g, '""') + '"';
+}
+
+function getColumnsOf(db, table) {
+  try {
+    const rows = db.prepare(`PRAGMA table_info(${quoteIdent(table)})`).all();
+    return new Set(rows.map(r => r.name));
+  } catch {
+    return new Set();
+  }
+}
+
+function detectSchema(db) {
+  const tables = new Set(
+    db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all().map(r => r.name)
+  );
+  return {
+    tables,
+    hasNodesNote: tables.has('Nodes_Note'),
+    hasNodesTag: tables.has('Nodes_Tag'),
+    hasNodesNotebook: tables.has('Nodes_Notebook'),
+    hasCacheLookaside: tables.has('CacheLookaside'),
+  };
+}
+
+function pickColumn(cols, ...candidates) {
+  for (const c of candidates) if (cols.has(c)) return c;
+  return null;
+}
+
+function safeJsonParse(s) {
+  if (typeof s !== 'string' || !s) return null;
+  try { return JSON.parse(s); } catch { return null; }
+}
+
+function ensureEnexDate(s) {
+  if (s == null) return null;
+  if (typeof s === 'number' && Number.isFinite(s)) {
+    return formatEnexFromDate(new Date(s));
+  }
+  if (typeof s !== 'string') return null;
+  if (/^\d{8}T\d{6}Z$/.test(s)) return s;
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return null;
+  return formatEnexFromDate(d);
+}
+
+function formatEnexFromDate(d) {
+  const pad = n => String(n).padStart(2, '0');
+  return (
+    d.getUTCFullYear().toString() +
+    pad(d.getUTCMonth() + 1) +
+    pad(d.getUTCDate()) +
+    'T' +
+    pad(d.getUTCHours()) +
+    pad(d.getUTCMinutes()) +
+    pad(d.getUTCSeconds()) +
+    'Z'
+  );
+}
+
+/**
+ * Replace local resource references in cached HTML (which point at on-disk
+ * files in Evernote's resource cache) with a plain-English marker so the
+ * resulting OneNote page does not display a broken file:// or
+ * evernote+resource:// link. v1 is text-only — these markers tell the
+ * user to use --batch with .enex if they need full-fidelity images.
+ */
+function scrubLocalResourceRefs(html) {
+  if (!html || typeof html !== 'string') return html || '';
+  // <img src="evernote+resource://…" /> or src="file:…" or src="C:\…"
+  html = html.replace(
+    /<img\b[^>]*\bsrc=(["'])(evernote\+resource:\/\/|file:\/\/|[a-zA-Z]:\\|\/[^/])[^"']*\1[^>]*\/?\s*>/gi,
+    '[image not included — export from Evernote for full content]'
+  );
+  // <a href="evernote+resource://…">label</a>
+  html = html.replace(
+    /<a\b[^>]*\bhref=(["'])evernote\+resource:\/\/[^"']*\1[^>]*>([\s\S]*?)<\/a>/gi,
+    '[attachment not included — export from Evernote for full content]'
+  );
+  return html;
+}
+
+function buildTagLookup(db, schema) {
+  const map = new Map();
+  if (!schema.hasNodesTag) return map;
+  const cols = getColumnsOf(db, 'Nodes_Tag');
+  const idCol = pickColumn(cols, 'TKey', 'guid', 'id');
+  const valCol = pickColumn(cols, 'TValue', 'value', 'data');
+  if (!idCol || !valCol) return map;
+  let rows;
+  try {
+    rows = db.prepare(
+      `SELECT ${quoteIdent(idCol)} AS id, ${quoteIdent(valCol)} AS val FROM Nodes_Tag`
+    ).all();
+  } catch { return map; }
+  for (const r of rows) {
+    const obj = safeJsonParse(r.val);
+    let name = null;
+    if (obj && typeof obj === 'object') {
+      name = obj.name || obj.label || (obj.NodeFields && obj.NodeFields.name) || null;
+    } else if (typeof r.val === 'string' && r.val.length > 0 && r.val.length < 80) {
+      name = r.val;
+    }
+    if (name) map.set(r.id, name);
+  }
+  return map;
+}
+
+function makeBodyLookup(db, schema) {
+  if (!schema.hasCacheLookaside) {
+    return () => null;
+  }
+  const cols = getColumnsOf(db, 'CacheLookaside');
+  const idCol = pickColumn(cols, 'TKey', 'key', 'id');
+  const valCol = pickColumn(cols, 'TValue', 'value', 'data');
+  if (!idCol || !valCol) return () => null;
+
+  // Try a handful of common key shapes — different conduit versions key
+  // the body row by raw GUID, by `Note:GUID`, or by `Note:GUID:content`.
+  const stmt = db.prepare(
+    `SELECT ${quoteIdent(valCol)} AS val FROM CacheLookaside ` +
+    `WHERE ${quoteIdent(idCol)} = ? OR ${quoteIdent(idCol)} = ? ` +
+    `OR ${quoteIdent(idCol)} = ? OR ${quoteIdent(idCol)} = ? LIMIT 1`
+  );
+
+  return function lookupBody(noteId) {
+    const variants = [
+      `${noteId}`,
+      `Note:${noteId}`,
+      `note:${noteId}`,
+      `Note:${noteId}:content`,
+    ];
+    let row;
+    try {
+      row = stmt.get(...variants);
+    } catch { return null; }
+    if (!row || row.val == null) return null;
+    const val = row.val;
+    if (typeof val !== 'string') return null;
+
+    const parsed = safeJsonParse(val);
+    if (parsed && typeof parsed === 'object') {
+      if (typeof parsed.html === 'string') return parsed.html;
+      if (typeof parsed.body === 'string') return parsed.body;
+      if (typeof parsed.content === 'string') return parsed.content;
+    }
+    return val;
+  };
+}
+
+/**
+ * Yield notes from the cache one at a time. Output shape matches
+ * enex-parser.parseEnexFile() so importNotes() consumes it unchanged.
+ *
+ * Yields three kinds of objects:
+ *   - normal note (with title, content, etc.)
+ *   - { _skip: true, reason: 'no-body', guid, title } — note metadata
+ *     present but body not yet downloaded to local cache
+ *   - { _skip: true, reason: 'unparseable-metadata', guid }
+ */
+function* iterateNotes(db, { schema = null } = {}) {
+  const s = schema || detectSchema(db);
+  if (!s.hasNodesNote) {
+    throw new Error(
+      'This SQLite file does not look like an Evernote cache (no Nodes_Note table).\n' +
+      '  Confirm Evernote v10 or v11 is installed, or pass --cache-path "<file>" explicitly.'
+    );
+  }
+
+  const tagById = buildTagLookup(db, s);
+  const lookupBody = makeBodyLookup(db, s);
+
+  const noteCols = getColumnsOf(db, 'Nodes_Note');
+  const idCol = pickColumn(noteCols, 'TKey', 'guid', 'id');
+  const valCol = pickColumn(noteCols, 'TValue', 'value', 'data');
+  if (!idCol || !valCol) {
+    throw new Error(
+      'Unexpected Nodes_Note schema (no recognised id/value columns).\n' +
+      '  This Evernote build may be too old or too new for this importer version.'
+    );
+  }
+
+  const stmt = db.prepare(
+    `SELECT ${quoteIdent(idCol)} AS id, ${quoteIdent(valCol)} AS val FROM Nodes_Note`
+  );
+
+  for (const row of stmt.iterate()) {
+    const meta = safeJsonParse(row.val);
+    if (!meta || typeof meta !== 'object') {
+      yield { _skip: true, reason: 'unparseable-metadata', guid: row.id };
+      continue;
+    }
+    // NodeFields wrapping is used in some conduit versions
+    const fields = (meta.NodeFields && typeof meta.NodeFields === 'object') ? meta.NodeFields : meta;
+
+    const title = (fields.title && String(fields.title)) || 'Untitled Note';
+    const created =
+      ensureEnexDate(fields.created) ||
+      ensureEnexDate(fields.createdAt) ||
+      ensureEnexDate(fields.created_at) ||
+      null;
+    const updated =
+      ensureEnexDate(fields.updated) ||
+      ensureEnexDate(fields.updatedAt) ||
+      ensureEnexDate(fields.updated_at) ||
+      null;
+
+    const tagGuids = Array.isArray(fields.tagGuids) ? fields.tagGuids
+      : Array.isArray(fields.tags) ? fields.tags
+      : [];
+    const tags = tagGuids.map(g => tagById.get(g)).filter(Boolean);
+
+    const body = lookupBody(row.id);
+    if (body == null || body === '') {
+      yield { _skip: true, reason: 'no-body', guid: row.id, title };
+      continue;
+    }
+
+    const wrapped = `<en-note>${scrubLocalResourceRefs(body)}</en-note>`;
+
+    yield {
+      title,
+      created,
+      updated,
+      tags,
+      content: wrapped,
+      resources: [],
+      author: fields.author || null,
+      sourceUrl: fields.sourceUrl || fields.sourceURL || null,
+      _guid: row.id,
+    };
+  }
+}
+
+/**
+ * Quick counts for the dry-run / status display. Approximate — body
+ * presence is checked via the same key-variant set used by makeBodyLookup
+ * (we don't reopen each row in JS, we count CacheLookaside rows whose
+ * key references a Nodes_Note row).
+ */
+function summarizeCache(db, { schema = null } = {}) {
+  const s = schema || detectSchema(db);
+  if (!s.hasNodesNote) return { total: 0, withBody: 0, withoutBody: 0, available: false };
+
+  const noteCols = getColumnsOf(db, 'Nodes_Note');
+  const noteIdCol = pickColumn(noteCols, 'TKey', 'guid', 'id');
+  if (!noteIdCol) return { total: 0, withBody: 0, withoutBody: 0, available: false };
+
+  const total = db.prepare('SELECT COUNT(*) AS c FROM Nodes_Note').get().c;
+
+  let withBody = 0;
+  if (s.hasCacheLookaside) {
+    const cacheCols = getColumnsOf(db, 'CacheLookaside');
+    const cacheIdCol = pickColumn(cacheCols, 'TKey', 'key', 'id');
+    if (cacheIdCol) {
+      try {
+        // Count Nodes_Note rows that have any matching CacheLookaside entry.
+        const r = db.prepare(
+          `SELECT COUNT(DISTINCT n.${quoteIdent(noteIdCol)}) AS c FROM Nodes_Note n ` +
+          `JOIN CacheLookaside c ON ` +
+          `c.${quoteIdent(cacheIdCol)} = n.${quoteIdent(noteIdCol)} ` +
+          `OR c.${quoteIdent(cacheIdCol)} = 'Note:' || n.${quoteIdent(noteIdCol)} ` +
+          `OR c.${quoteIdent(cacheIdCol)} = 'note:' || n.${quoteIdent(noteIdCol)} ` +
+          `OR c.${quoteIdent(cacheIdCol)} = 'Note:' || n.${quoteIdent(noteIdCol)} || ':content'`
+        ).get();
+        withBody = r.c || 0;
+      } catch {
+        withBody = 0;
+      }
+    }
+  }
+  return {
+    total,
+    withBody: Math.min(withBody, total),
+    withoutBody: Math.max(0, total - Math.min(withBody, total)),
+    available: true,
+  };
+}
+
+module.exports = {
+  LOCAL_FILENAME_SLOT,
+  LOCAL_NOTEBOOK_NAME,
+  getCandidateCacheDirs,
+  discoverCacheFile,
+  openReadOnly,
+  detectSchema,
+  iterateNotes,
+  summarizeCache,
+  scrubLocalResourceRefs,
+  ensureEnexDate,
+  // exposed for tests
+  _internals: { quoteIdent, getColumnsOf, pickColumn, buildTagLookup, makeBodyLookup },
+};

--- a/tests/cli-from-local.test.js
+++ b/tests/cli-from-local.test.js
@@ -1,0 +1,157 @@
+'use strict';
+/**
+ * CLI integration tests for --from-local. We seed a real on-disk SQLite
+ * file that mimics the Evernote v10/v11 conduit cache, then run the CLI
+ * with `--from-local --cache-path <file> --dry-run` and assert on the
+ * stdout summary + report.
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+
+const CLI = path.join(__dirname, '..', 'src', 'index.js');
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `enex-cli-${label}-`));
+}
+
+function run(args, opts = {}) {
+  const { env = {}, cwd } = opts;
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ONENOTE_ACCESS_TOKEN: '', MSAL_NO_INTERACTIVE: '1', ...env },
+    timeout: 30000,
+    cwd,
+  });
+}
+
+function seedCacheFile(cacheFile, { notes, cacheRows }) {
+  const db = new Database(cacheFile);
+  db.exec(`
+    CREATE TABLE Nodes_Note      (TKey TEXT PRIMARY KEY, TValue TEXT);
+    CREATE TABLE Nodes_Tag       (TKey TEXT PRIMARY KEY, TValue TEXT);
+    CREATE TABLE CacheLookaside  (TKey TEXT PRIMARY KEY, TValue TEXT);
+  `);
+  const insN = db.prepare('INSERT INTO Nodes_Note (TKey, TValue) VALUES (?, ?)');
+  const insC = db.prepare('INSERT INTO CacheLookaside (TKey, TValue) VALUES (?, ?)');
+  for (const n of notes) insN.run(n.key, JSON.stringify(n.value));
+  for (const c of (cacheRows || [])) insC.run(c.key, c.value);
+  db.close();
+}
+
+describe('CLI — --from-local', () => {
+  test('--help mentions --from-local and --cache-path', () => {
+    const { status, stdout } = run(['--help']);
+    assert.equal(status, 0);
+    assert.match(stdout, /--from-local/);
+    assert.match(stdout, /--cache-path/);
+  });
+
+  test('--from-local + --batch is rejected with a helpful message', () => {
+    const { status, stderr } = run(['--from-local', '--batch', '/some/dir', '--dry-run']);
+    assert.equal(status, 1);
+    assert.match(stderr, /cannot be combined/i);
+  });
+
+  test('--from-local + positional .enex path is rejected', () => {
+    const { status, stderr } = run(['--from-local', 'foo.enex', '--dry-run']);
+    assert.equal(status, 1);
+    assert.match(stderr, /cannot be combined/i);
+  });
+
+  test('--cache-path without --from-local is rejected', () => {
+    const { status, stderr } = run(['--cache-path', 'foo.sql', '--dry-run']);
+    assert.equal(status, 1);
+    assert.match(stderr, /can only be used with --from-local/i);
+  });
+
+  test('--cache-path with no value is rejected', () => {
+    const { status, stderr } = run(['--from-local', '--cache-path']);
+    assert.equal(status, 1);
+    assert.match(stderr, /requires a path argument/i);
+  });
+
+  test('--from-local --dry-run reads notes from a seeded cache', () => {
+    const cwdDir = makeTempDir('fromlocal-dry');
+    const cacheDir = makeTempDir('fromlocal-cache');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'g1', value: { title: 'Cached note one', created: '2026-01-01T00:00:00Z' } },
+          { key: 'g2', value: { title: 'Cached note two', created: '2026-02-01T00:00:00Z' } },
+        ],
+        cacheRows: [
+          { key: 'g1', value: '<p>One</p>' },
+          { key: 'g2', value: '<p>Two</p>' },
+        ],
+      });
+
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheFile, '--dry-run'],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout was:\n${stdout}`);
+      assert.match(stdout, /local Evernote cache/i);
+      assert.match(stdout, /2 note\(s\) found in local cache/);
+      assert.match(stdout, /Cached note one/);
+      assert.match(stdout, /Cached note two/);
+      assert.match(stdout, /DRY RUN complete/i);
+    } finally {
+      fs.rmSync(cwdDir, { recursive: true, force: true });
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  test('--from-local reports notes whose body has not been downloaded', () => {
+    const cwdDir = makeTempDir('fromlocal-skip');
+    const cacheDir = makeTempDir('fromlocal-skip-c');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'has-body', value: { title: 'A',  created: '2026-01-01T00:00:00Z' } },
+          { key: 'no-body-1', value: { title: 'B', created: '2026-01-01T00:00:00Z' } },
+          { key: 'no-body-2', value: { title: 'C', created: '2026-01-01T00:00:00Z' } },
+        ],
+        cacheRows: [{ key: 'has-body', value: '<p>body</p>' }],
+      });
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheFile, '--dry-run'],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout was:\n${stdout}`);
+      // Total / withBody / withoutBody banner
+      assert.match(stdout, /3 note\(s\) found in local cache/);
+      assert.match(stdout, /1 have body text; 2 skipped — body not yet downloaded/);
+      // The skip-list preview line names some guids
+      assert.match(stdout, /content not yet downloaded/);
+      // The big-box message is shown when at-or-more skipped than imported
+      assert.match(stdout, /don.?t have content yet/);
+      assert.match(stdout, /Make available offline/);
+    } finally {
+      fs.rmSync(cwdDir, { recursive: true, force: true });
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  test('--from-local with --cache-path pointing at an empty dir errors clearly', () => {
+    const cacheDir = makeTempDir('fromlocal-empty');
+    try {
+      const { stdout, stderr } = run(
+        ['--from-local', '--cache-path', cacheDir, '--dry-run'],
+        { cwd: cacheDir },
+      );
+      // The reader throws with a message naming the missing pattern;
+      // index.js logs that message to stderr and increments totalFailed.
+      const combined = (stdout || '') + '\n' + (stderr || '');
+      assert.match(combined, /No Evernote cache .*found in/i);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/from-local-extended.test.js
+++ b/tests/from-local-extended.test.js
@@ -1,0 +1,616 @@
+'use strict';
+/**
+ * Extended tests for --from-local (acceptance criteria #6).
+ * Covers parser edge-cases, --output-html pipeline integration,
+ * auto-detect CLI behaviour, and resumability.
+ *
+ * Cases already covered by local-cache-reader.test.js and
+ * cli-from-local.test.js are NOT duplicated here.
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+
+const { iterateNotes, openReadOnly } = require('../src/local-cache-reader');
+
+const CLI = path.join(__dirname, '..', 'src', 'index.js');
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `enex-ext-${label}-`));
+}
+
+function run(args, opts = {}) {
+  const { env = {}, cwd } = opts;
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ONENOTE_ACCESS_TOKEN: '', MSAL_NO_INTERACTIVE: '1', ...env },
+    timeout: 30_000,
+    cwd,
+  });
+}
+
+function seedCache(db, { notes = [], tags = [], cacheRows = [] } = {}) {
+  db.exec(`
+    CREATE TABLE Nodes_Note      (TKey TEXT PRIMARY KEY, TValue TEXT);
+    CREATE TABLE Nodes_Tag       (TKey TEXT PRIMARY KEY, TValue TEXT);
+    CREATE TABLE CacheLookaside  (TKey TEXT PRIMARY KEY, TValue TEXT);
+  `);
+  const insN = db.prepare('INSERT INTO Nodes_Note (TKey, TValue) VALUES (?, ?)');
+  const insT = db.prepare('INSERT INTO Nodes_Tag  (TKey, TValue) VALUES (?, ?)');
+  const insC = db.prepare('INSERT INTO CacheLookaside (TKey, TValue) VALUES (?, ?)');
+  for (const n of notes) insN.run(n.key, JSON.stringify(n.value));
+  for (const t of tags)  insT.run(t.key, JSON.stringify(t.value));
+  for (const c of cacheRows) insC.run(c.key, c.value);
+}
+
+function seedCacheFile(cacheFile, opts) {
+  const db = new Database(cacheFile);
+  seedCache(db, opts);
+  db.close();
+}
+
+function findHtmlFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...findHtmlFiles(full));
+    else if (entry.name.endsWith('.html')) results.push(full);
+  }
+  return results;
+}
+
+// ── Parser unit tests — edge cases not in local-cache-reader.test.js ─────────
+
+describe('local-cache-reader (extended) — iterateNotes edge cases', () => {
+  test('empty Nodes_Note table yields no items', () => {
+    const db = new Database(':memory:');
+    seedCache(db);
+    const out = [...iterateNotes(db)];
+    assert.equal(out.length, 0);
+    db.close();
+  });
+
+  test('multiple notes are all yielded', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [
+        { key: 'n1', value: { title: 'First',  created: '2026-01-01T00:00:00Z' } },
+        { key: 'n2', value: { title: 'Second', created: '2026-01-02T00:00:00Z' } },
+        { key: 'n3', value: { title: 'Third',  created: '2026-01-03T00:00:00Z' } },
+      ],
+      cacheRows: [
+        { key: 'n1', value: '<p>A</p>' },
+        { key: 'n2', value: '<p>B</p>' },
+        { key: 'n3', value: '<p>C</p>' },
+      ],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 3);
+    const titles = out.map(n => n.title).sort();
+    assert.deepEqual(titles, ['First', 'Second', 'Third']);
+    db.close();
+  });
+
+  test('Unicode note titles are preserved exactly', () => {
+    const db = new Database(':memory:');
+    const unicodeTitle = 'Üïçödé Títlé 日本語 🦄';
+    seedCache(db, {
+      notes: [{ key: 'u1', value: { title: unicodeTitle, created: '2026-03-01T00:00:00Z' } }],
+      cacheRows: [{ key: 'u1', value: '<p>unicode body</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].title, unicodeTitle);
+    db.close();
+  });
+
+  test('note:<guid> lowercase key variant resolves body', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'g99', value: { title: 'Lowercase variant', created: '2026-02-01T00:00:00Z' } }],
+      cacheRows: [{ key: 'note:g99', value: '<div>lowercase body</div>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.match(out[0].content, /lowercase body/);
+    db.close();
+  });
+
+  test('Note:<guid>:content key variant resolves body', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'g77', value: { title: 'Colon-content variant', created: '2026-02-01T00:00:00Z' } }],
+      cacheRows: [{ key: 'Note:g77:content', value: '<div>content-suffix body</div>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.match(out[0].content, /content-suffix body/);
+    db.close();
+  });
+
+  test('JSON body with "body" key is unwrapped', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'jb', value: { title: 'Body key', created: '2026-01-01T00:00:00Z' } }],
+      cacheRows: [{ key: 'jb', value: JSON.stringify({ body: '<p>from body key</p>' }) }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.match(out[0].content, /from body key/);
+    db.close();
+  });
+
+  test('JSON body with "content" key is unwrapped', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'jc', value: { title: 'Content key', created: '2026-01-01T00:00:00Z' } }],
+      cacheRows: [{ key: 'jc', value: JSON.stringify({ content: '<p>from content key</p>' }) }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.match(out[0].content, /from content key/);
+    db.close();
+  });
+
+  test('NodeFields wrapper extracts title and dates', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{
+        key: 'nf',
+        value: {
+          NodeFields: {
+            title: 'From NodeFields',
+            created: '2026-04-10T08:00:00Z',
+            updated: '2026-04-11T09:00:00Z',
+          },
+        },
+      }],
+      cacheRows: [{ key: 'nf', value: '<p>wrapped body</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].title, 'From NodeFields');
+    assert.equal(out[0].created, '20260410T080000Z');
+    assert.equal(out[0].updated, '20260411T090000Z');
+    db.close();
+  });
+
+  test('unparseable metadata row yields _skip with reason=unparseable-metadata', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE Nodes_Note     (TKey TEXT PRIMARY KEY, TValue TEXT);
+      CREATE TABLE CacheLookaside (TKey TEXT PRIMARY KEY, TValue TEXT);
+    `);
+    db.prepare('INSERT INTO Nodes_Note (TKey, TValue) VALUES (?, ?)').run('bad', 'not json at all !!!');
+    const out = [...iterateNotes(db)];
+    assert.equal(out.length, 1);
+    assert.equal(out[0]._skip, true);
+    assert.equal(out[0].reason, 'unparseable-metadata');
+    assert.equal(out[0].guid, 'bad');
+    db.close();
+  });
+
+  test('local resource refs in body are scrubbed before yielding', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 's1', value: { title: 'Has image', created: '2026-01-01T00:00:00Z' } }],
+      cacheRows: [{
+        key: 's1',
+        value: '<p>text</p><img src="evernote+resource://abc" /><p>after</p>',
+      }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.doesNotMatch(out[0].content, /evernote\+resource/);
+    assert.match(out[0].content, /image not included/);
+    db.close();
+  });
+});
+
+// ── openReadOnly error handling ───────────────────────────────────────────────
+
+describe('local-cache-reader (extended) — corrupt file error handling', () => {
+  test('gives a clean error when SQLite file is corrupt (error surfaces on first query)', () => {
+    // On all platforms, better-sqlite3 opens the file handle successfully but
+    // raises SQLITE_NOTADB ("file is not a database") on the first query.
+    // The observable behaviour for callers is: openReadOnly() succeeds, but
+    // iterateNotes() (or any query) throws a clean Error — no unhandled crash.
+    const tmpDir = makeTempDir('corrupt');
+    const corruptFile = path.join(tmpDir, 'corrupt.sql');
+    let db;
+    try {
+      fs.writeFileSync(corruptFile, 'this is not a sqlite database — just garbage bytes', 'utf8');
+      db = openReadOnly(corruptFile);           // must NOT throw
+      assert.ok(db, 'openReadOnly should return a db handle for a corrupt file');
+      assert.throws(
+        () => [...iterateNotes(db)],            // throws on first query
+        (err) => {
+          assert.ok(err instanceof Error, 'should throw a proper Error');
+          assert.match(err.message, /database|SQLITE/i, 'message should describe the SQLite issue');
+          return true;
+        },
+      );
+    } finally {
+      try { db && db.close(); } catch { /* ignore */ }
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* EBUSY on Windows — OS reclaims on reboot */ }
+    }
+  });
+});
+
+// ── Integration test — --from-local --output-html ────────────────────────────
+
+describe('CLI — --from-local --output-html', () => {
+  test('creates one HTML file per note from local cache', () => {
+    const cacheDir = makeTempDir('html-cache');
+    const outDir   = makeTempDir('html-out');
+    const cwdDir   = makeTempDir('html-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'h1', value: { title: 'HTML Note One', created: '2026-01-10T10:00:00Z' } },
+          { key: 'h2', value: { title: 'HTML Note Two', created: '2026-01-11T10:00:00Z' } },
+        ],
+        cacheRows: [
+          { key: 'h1', value: '<p>Body of note one</p>' },
+          { key: 'h2', value: '<p>Body of note two</p>' },
+        ],
+      });
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheFile, '--output-html', outDir],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout:\n${stdout}`);
+      const files = findHtmlFiles(outDir);
+      assert.equal(
+        files.length, 2,
+        `expected 2 HTML files, found: ${files.map(f => path.basename(f)).join(', ')}`,
+      );
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('HTML file contains the note title and body text', () => {
+    const cacheDir = makeTempDir('html-content-cache');
+    const outDir   = makeTempDir('html-content-out');
+    const cwdDir   = makeTempDir('html-content-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'c1', value: { title: 'My Titled Note', created: '2026-02-05T08:00:00Z' } },
+        ],
+        cacheRows: [
+          { key: 'c1', value: '<p>Specific body content XYZ</p>' },
+        ],
+      });
+      run(['--from-local', '--cache-path', cacheFile, '--output-html', outDir], { cwd: cwdDir });
+      const files = findHtmlFiles(outDir);
+      assert.ok(files.length >= 1, 'expected at least one HTML file');
+      const html = fs.readFileSync(files[0], 'utf8');
+      assert.match(html, /My Titled Note/);
+      assert.match(html, /Specific body content XYZ/);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('stdout reports "Saved:" for each note and "Imported: 2"', () => {
+    const cacheDir = makeTempDir('html-saved-cache');
+    const outDir   = makeTempDir('html-saved-out');
+    const cwdDir   = makeTempDir('html-saved-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 's1', value: { title: 'Save One', created: '2026-03-01T00:00:00Z' } },
+          { key: 's2', value: { title: 'Save Two', created: '2026-03-02T00:00:00Z' } },
+        ],
+        cacheRows: [
+          { key: 's1', value: '<p>body1</p>' },
+          { key: 's2', value: '<p>body2</p>' },
+        ],
+      });
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheFile, '--output-html', outDir],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout:\n${stdout}`);
+      assert.match(stdout, /Saved:/);
+      assert.match(stdout, /Imported: 2/);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('HTML output filenames contain no path-unsafe characters', () => {
+    const cacheDir = makeTempDir('html-safe-cache');
+    const outDir   = makeTempDir('html-safe-out');
+    const cwdDir   = makeTempDir('html-safe-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'safe1', value: { title: 'Note: With/Special|Chars?', created: '2026-01-01T00:00:00Z' } },
+        ],
+        cacheRows: [{ key: 'safe1', value: '<p>body</p>' }],
+      });
+      run(['--from-local', '--cache-path', cacheFile, '--output-html', outDir], { cwd: cwdDir });
+      const files = findHtmlFiles(outDir);
+      for (const f of files) {
+        assert.doesNotMatch(path.basename(f), /[/\\?%*:|"<>]/);
+      }
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('notes with missing body are skipped but notes with body still produce HTML', () => {
+    const cacheDir = makeTempDir('html-mixed-cache');
+    const outDir   = makeTempDir('html-mixed-out');
+    const cwdDir   = makeTempDir('html-mixed-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'good', value: { title: 'Has Body',  created: '2026-01-01T00:00:00Z' } },
+          { key: 'bad',  value: { title: 'No Body',   created: '2026-01-02T00:00:00Z' } },
+        ],
+        cacheRows: [{ key: 'good', value: '<p>real body</p>' }],
+      });
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheFile, '--output-html', outDir],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout:\n${stdout}`);
+      const files = findHtmlFiles(outDir);
+      assert.equal(files.length, 1, 'only the note with a body should produce an HTML file');
+      assert.match(stdout, /Imported: 1/);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+});
+
+// ── CLI flag — auto-detect behaviour when Evernote not present ───────────────
+
+describe('CLI — --from-local auto-detect (no --cache-path)', () => {
+  test('reports "could not find" when no Evernote cache exists on the system', () => {
+    // Redirect all OS-specific Evernote cache dirs to a temp directory that
+    // contains no *RemoteGraph.sql file, forcing getCandidateCacheDirs() to
+    // return locations that do not exist.
+    const emptyDir = makeTempDir('no-evernote');
+    const cwdDir   = makeTempDir('no-evernote-cwd');
+    try {
+      const { stdout, stderr } = run(['--from-local', '--dry-run'], {
+        env: {
+          LOCALAPPDATA: emptyDir,   // Windows primary
+          APPDATA: emptyDir,        // Windows secondary
+          HOME: emptyDir,           // macOS / Linux
+          XDG_CONFIG_HOME: emptyDir,
+          XDG_DATA_HOME: emptyDir,
+        },
+        cwd: cwdDir,
+      });
+      const combined = (stdout || '') + '\n' + (stderr || '');
+      assert.match(combined, /could not find.*evernote|no.*evernote.*cache/i);
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('auto-detects cache when --cache-path points at directory containing RemoteGraph.sql', () => {
+    // Uses --cache-path pointing at a directory (not the file directly) to
+    // exercise the findSqlInDir() branch inside discoverCacheFile().
+    const cacheDir = makeTempDir('autodir-cache');
+    const outDir   = makeTempDir('autodir-out');
+    const cwdDir   = makeTempDir('autodir-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User42+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [{ key: 'a1', value: { title: 'Auto Dir', created: '2026-05-01T00:00:00Z' } }],
+        cacheRows: [{ key: 'a1', value: '<p>auto-dir body</p>' }],
+      });
+      // Pass the directory, not the file — CLI should find the .sql inside
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheDir, '--dry-run'],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout:\n${stdout}`);
+      assert.match(stdout, /1 note\(s\) found in local cache/);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Resumability tests ────────────────────────────────────────────────────────
+
+describe('CLI — --from-local resumability', () => {
+  test('--output-html run writes progress.json with __local__ file key', () => {
+    const cacheDir = makeTempDir('res1-cache');
+    const outDir   = makeTempDir('res1-out');
+    const cwdDir   = makeTempDir('res1-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'r1', value: { title: 'Resume Note A', created: '2026-04-01T00:00:00Z' } },
+          { key: 'r2', value: { title: 'Resume Note B', created: '2026-04-02T00:00:00Z' } },
+        ],
+        cacheRows: [
+          { key: 'r1', value: '<p>resumable A</p>' },
+          { key: 'r2', value: '<p>resumable B</p>' },
+        ],
+      });
+      const { status } = run(
+        ['--from-local', '--cache-path', cacheFile, '--output-html', outDir],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0);
+
+      const progressPath = path.join(cwdDir, 'progress.json');
+      assert.ok(fs.existsSync(progressPath), 'progress.json should be created');
+      const data = JSON.parse(fs.readFileSync(progressPath, 'utf8'));
+      assert.equal(data.version, 2);
+      const fileEntry = data.files['__local__'];
+      assert.ok(fileEntry, '__local__ key should exist in progress.json');
+      const importedKeys = Object.keys(fileEntry.imported);
+      assert.equal(importedKeys.length, 2);
+      assert.ok(importedKeys.some(k => k.startsWith('__local__::Resume Note A::')));
+      assert.ok(importedKeys.some(k => k.startsWith('__local__::Resume Note B::')));
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('--dry-run --resume skips notes already in progress.json and imports the rest', () => {
+    // NOTE: --output-html --resume re-imports notes with null onenote_page_id (verifyImport
+    // returns "missing" for null pageIds). --dry-run --resume correctly short-circuits before
+    // verifyImport, so dry-run is the right mode for testing skip behaviour.
+    const cacheDir = makeTempDir('res2-cache');
+    const cwdDir   = makeTempDir('res2-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'p1', value: { title: 'Already Done',  created: '2026-04-01T00:00:00Z' } },
+          { key: 'p2', value: { title: 'Still Pending', created: '2026-04-02T00:00:00Z' } },
+        ],
+        cacheRows: [
+          { key: 'p1', value: '<p>done</p>' },
+          { key: 'p2', value: '<p>pending</p>' },
+        ],
+      });
+
+      // Pre-seed progress marking "Already Done" as imported.
+      // Key format: __local__::<title>::<created-enex>
+      // '2026-04-01T00:00:00Z' → ensureEnexDate → '20260401T000000Z'
+      const progressData = {
+        version: 2,
+        files: {
+          '__local__': {
+            imported: {
+              '__local__::Already Done::20260401T000000Z': {
+                onenote_page_id: null,
+                timestamp: new Date().toISOString(),
+              },
+            },
+          },
+        },
+      };
+      fs.writeFileSync(path.join(cwdDir, 'progress.json'), JSON.stringify(progressData, null, 2));
+
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheFile, '--dry-run', '--resume'],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout:\n${stdout}`);
+      assert.match(stdout, /Imported: 1/);
+      assert.match(stdout, /Skipped:\s+1/i);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('without --resume all notes are re-imported even if progress.json has them', () => {
+    const cacheDir = makeTempDir('res3-cache');
+    const cwdDir   = makeTempDir('res3-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'x1', value: { title: 'Already Done 2', created: '2026-04-01T00:00:00Z' } },
+        ],
+        cacheRows: [{ key: 'x1', value: '<p>already done body</p>' }],
+      });
+
+      const progressData = {
+        version: 2,
+        files: {
+          '__local__': {
+            imported: {
+              '__local__::Already Done 2::20260401T000000Z': {
+                onenote_page_id: null,
+                timestamp: new Date().toISOString(),
+              },
+            },
+          },
+        },
+      };
+      fs.writeFileSync(path.join(cwdDir, 'progress.json'), JSON.stringify(progressData, null, 2));
+
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheFile, '--dry-run'],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout:\n${stdout}`);
+      // Without --resume, progress.json is ignored for skip decisions
+      assert.match(stdout, /Imported: 1/);
+      assert.doesNotMatch(stdout, /Skipped:/);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('second --output-html run appends collision-safe filenames (no crash)', () => {
+    // Simulates: first run completes, second run re-imports cleanly (no crash,
+    // no stale HTML from first run conflicts). Collision handler appends (2).
+    const cacheDir = makeTempDir('res4-cache');
+    const outDir   = makeTempDir('res4-out');
+    const cwdDir   = makeTempDir('res4-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [
+          { key: 'rr1', value: { title: 'Repeat Note', created: '2026-05-01T00:00:00Z' } },
+        ],
+        cacheRows: [{ key: 'rr1', value: '<p>repeat body</p>' }],
+      });
+      // First run
+      const r1 = run(
+        ['--from-local', '--cache-path', cacheFile, '--output-html', outDir],
+        { cwd: cwdDir },
+      );
+      assert.equal(r1.status, 0);
+      // Second run into same dir (collision → "Repeat Note (2).html")
+      const r2 = run(
+        ['--from-local', '--cache-path', cacheFile, '--output-html', outDir],
+        { cwd: cwdDir },
+      );
+      assert.equal(r2.status, 0);
+      const files = findHtmlFiles(outDir);
+      // Both runs should have produced files; both should be safe filenames
+      assert.ok(files.length >= 1);
+      for (const f of files) {
+        assert.doesNotMatch(path.basename(f), /[/\\?%*:|"<>]/);
+      }
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/from-local-parser-extra.test.js
+++ b/tests/from-local-parser-extra.test.js
@@ -1,0 +1,375 @@
+'use strict';
+/**
+ * Additional parser unit + round-trip integration tests for --from-local.
+ * Acceptance criteria #6 — gaps not covered by local-cache-reader.test.js
+ * or from-local-extended.test.js:
+ *
+ *   ① Large dataset (100 notes) correctness
+ *   ② Alternative metadata field names (tags/tagGuids, createdAt/created_at,
+ *      updatedAt/updated_at, sourceURL)
+ *   ③ openReadOnly on a truly non-existent file path
+ *   ④ Unicode body content preserved end-to-end through --output-html
+ *   ⑤ Resource marker text ([image not included]) visible in final HTML file
+ *   ⑥ enex-parser shape parity — all expected keys present in local reader output
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+
+const {
+  iterateNotes,
+  openReadOnly,
+  scrubLocalResourceRefs,
+} = require('../src/local-cache-reader');
+
+const CLI = path.join(__dirname, '..', 'src', 'index.js');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `enex-extra-${label}-`));
+}
+
+function run(args, opts = {}) {
+  const { env = {}, cwd } = opts;
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ONENOTE_ACCESS_TOKEN: '', MSAL_NO_INTERACTIVE: '1', ...env },
+    timeout: 30_000,
+    cwd,
+  });
+}
+
+function seedCache(db, { notes = [], tags = [], cacheRows = [] } = {}) {
+  db.exec(`
+    CREATE TABLE Nodes_Note      (TKey TEXT PRIMARY KEY, TValue TEXT);
+    CREATE TABLE Nodes_Tag       (TKey TEXT PRIMARY KEY, TValue TEXT);
+    CREATE TABLE CacheLookaside  (TKey TEXT PRIMARY KEY, TValue TEXT);
+  `);
+  const insN = db.prepare('INSERT INTO Nodes_Note (TKey, TValue) VALUES (?, ?)');
+  const insT = db.prepare('INSERT INTO Nodes_Tag  (TKey, TValue) VALUES (?, ?)');
+  const insC = db.prepare('INSERT INTO CacheLookaside (TKey, TValue) VALUES (?, ?)');
+  for (const n of notes) insN.run(n.key, JSON.stringify(n.value));
+  for (const t of tags)  insT.run(t.key, JSON.stringify(t.value));
+  for (const c of cacheRows) insC.run(c.key, c.value);
+}
+
+function seedCacheFile(cacheFile, opts) {
+  const db = new Database(cacheFile);
+  seedCache(db, opts);
+  db.close();
+}
+
+function findHtmlFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...findHtmlFiles(full));
+    else if (entry.name.endsWith('.html')) results.push(full);
+  }
+  return results;
+}
+
+// ─── ① Large dataset — 100 notes ─────────────────────────────────────────────
+
+describe('local-cache-reader (extra) — large dataset', () => {
+  test('iterates 100 notes without loss or duplication', () => {
+    const db = new Database(':memory:');
+    const N = 100;
+    const notes = [];
+    const cacheRows = [];
+    for (let i = 0; i < N; i++) {
+      const guid = `note-${String(i).padStart(3, '0')}`;
+      notes.push({
+        key: guid,
+        value: { title: `Note ${i}`, created: `2026-01-${String((i % 28) + 1).padStart(2, '0')}T00:00:00Z` },
+      });
+      cacheRows.push({ key: guid, value: `<p>Body of note ${i}</p>` });
+    }
+    seedCache(db, { notes, cacheRows });
+
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, N, `Expected ${N} notes, got ${out.length}`);
+
+    // Check no duplicates by title
+    const titles = new Set(out.map(n => n.title));
+    assert.equal(titles.size, N, 'Duplicate titles detected — notes were duplicated');
+
+    // Spot-check first and last
+    const sortedTitles = [...titles].sort();
+    assert.ok(sortedTitles.includes('Note 0'));
+    assert.ok(sortedTitles.includes('Note 99'));
+    db.close();
+  });
+
+  test('100-note cache with 30 missing bodies — correct skip/yield split', () => {
+    const db = new Database(':memory:');
+    const notes = [];
+    const cacheRows = [];
+    for (let i = 0; i < 100; i++) {
+      const guid = `n${i}`;
+      notes.push({ key: guid, value: { title: `T${i}`, created: '2026-01-01T00:00:00Z' } });
+      if (i >= 70) cacheRows.push({ key: guid, value: `<p>body ${i}</p>` });
+    }
+    seedCache(db, { notes, cacheRows });
+
+    const all = [...iterateNotes(db)];
+    const real   = all.filter(n => !n._skip);
+    const skipped = all.filter(n => n._skip && n.reason === 'no-body');
+    assert.equal(real.length, 30);
+    assert.equal(skipped.length, 70);
+    db.close();
+  });
+});
+
+// ─── ② Alternative metadata field names ──────────────────────────────────────
+
+describe('local-cache-reader (extra) — alternative metadata field names', () => {
+  test('uses "tags" array when "tagGuids" is absent', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{
+        key: 'tg1',
+        value: { title: 'Tags-field note', created: '2026-01-01T00:00:00Z', tags: ['tag-a', 'tag-b'] },
+      }],
+      tags: [
+        { key: 'tag-a', value: { name: 'alpha' } },
+        { key: 'tag-b', value: { name: 'beta' } },
+      ],
+      cacheRows: [{ key: 'tg1', value: '<p>body</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.deepEqual(out[0].tags.sort(), ['alpha', 'beta']);
+    db.close();
+  });
+
+  test('uses "createdAt" when "created" is absent', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'ca1', value: { title: 'createdAt note', createdAt: '2026-03-10T14:00:00Z' } }],
+      cacheRows: [{ key: 'ca1', value: '<p>body</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out[0].created, '20260310T140000Z');
+    db.close();
+  });
+
+  test('uses "created_at" (snake_case) when "created" and "createdAt" are absent', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'sc1', value: { title: 'snake_case date', created_at: '2026-04-20T08:30:00Z' } }],
+      cacheRows: [{ key: 'sc1', value: '<p>body</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out[0].created, '20260420T083000Z');
+    db.close();
+  });
+
+  test('uses "updatedAt" when "updated" is absent', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'ua1', value: { title: 'updatedAt note', created: '2026-01-01T00:00:00Z', updatedAt: '2026-05-01T12:00:00Z' } }],
+      cacheRows: [{ key: 'ua1', value: '<p>body</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out[0].updated, '20260501T120000Z');
+    db.close();
+  });
+
+  test('uses "updated_at" (snake_case) when "updated" and "updatedAt" are absent', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'sua1', value: { title: 'snake_case updated', created: '2026-01-01T00:00:00Z', updated_at: '2026-05-02T10:00:00Z' } }],
+      cacheRows: [{ key: 'sua1', value: '<p>body</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out[0].updated, '20260502T100000Z');
+    db.close();
+  });
+
+  test('uses "sourceURL" (uppercase URL) as fallback for sourceUrl', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'su1', value: { title: 'URL-upper', created: '2026-01-01T00:00:00Z', sourceURL: 'https://upper.example.com' } }],
+      cacheRows: [{ key: 'su1', value: '<p>body</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out[0].sourceUrl, 'https://upper.example.com');
+    db.close();
+  });
+});
+
+// ─── ③ openReadOnly on a non-existent file path ───────────────────────────────
+
+describe('local-cache-reader (extra) — openReadOnly error paths', () => {
+  test('throws a clear error when the file path does not exist', () => {
+    const missingPath = path.join(os.tmpdir(), `does-not-exist-${Date.now()}.sql`);
+    assert.throws(
+      () => openReadOnly(missingPath),
+      (err) => {
+        assert.ok(err instanceof Error, 'should throw an Error instance');
+        // better-sqlite3 with fileMustExist:true raises SQLITE_CANTOPEN
+        // ("unable to open database file") — NOT an ENOENT on all platforms.
+        const msg = err.message || '';
+        const code = err.code || '';
+        assert.ok(
+          /ENOENT|no such file|does not exist|unable to open|SQLITE_CANTOPEN/i.test(msg) ||
+          /ENOENT|SQLITE_CANTOPEN/i.test(code),
+          `Expected a "file not found" style error in: "${msg}" (code: "${code}")`
+        );
+        return true;
+      }
+    );
+  });
+});
+
+// ─── ④ enex-parser shape parity ──────────────────────────────────────────────
+
+describe('local-cache-reader (extra) — enex-parser shape parity', () => {
+  test('output object has all keys expected by importNotes()', () => {
+    // importNotes() accesses: title, created, updated, tags, content,
+    // resources, author, sourceUrl.  The extra _guid key is allowed.
+    const required = ['title', 'created', 'updated', 'tags', 'content', 'resources', 'author', 'sourceUrl'];
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'shape1', value: { title: 'Shape check', created: '2026-01-01T00:00:00Z', author: 'A', sourceUrl: 'https://x.com' } }],
+      cacheRows: [{ key: 'shape1', value: '<p>body</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    const note = out[0];
+    for (const key of required) {
+      assert.ok(key in note, `Missing required key "${key}" in local-cache note shape`);
+    }
+    // resources must be an array (even if empty)
+    assert.ok(Array.isArray(note.resources), 'resources must be an array');
+    // tags must be an array
+    assert.ok(Array.isArray(note.tags), 'tags must be an array');
+    // content must be a string
+    assert.equal(typeof note.content, 'string');
+    db.close();
+  });
+
+  test('resources array is always empty (v1 text-only) — no .dat files read', () => {
+    const db = new Database(':memory:');
+    // Note has a resource reference in its body (evernote+resource://)
+    // but resources array must be [] — v1 never reads .dat files from disk
+    seedCache(db, {
+      notes: [{ key: 'res1', value: { title: 'Has resource ref' } }],
+      cacheRows: [{
+        key: 'res1',
+        value: '<p>text</p><img src="evernote+resource://abc123" alt="img"/>',
+      }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.deepEqual(out[0].resources, [], 'resources must be empty — v1 is text-only, no .dat files read');
+    db.close();
+  });
+});
+
+// ─── ⑤ Unicode body content in --output-html ─────────────────────────────────
+
+describe('CLI (extra) — Unicode body content in --output-html', () => {
+  test('Unicode characters in note body are preserved in output HTML file', () => {
+    const cacheDir  = makeTempDir('uni-cache');
+    const outDir    = makeTempDir('uni-out');
+    const cwdDir    = makeTempDir('uni-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    const unicodeBody = '<p>Héllo Wörld — 日本語テスト — 🦄 emöji — €£¥</p>';
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [{ key: 'u1', value: { title: 'Unicode Body', created: '2026-01-01T00:00:00Z' } }],
+        cacheRows: [{ key: 'u1', value: unicodeBody }],
+      });
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheFile, '--output-html', outDir],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout:\n${stdout}`);
+      const files = findHtmlFiles(outDir);
+      assert.ok(files.length >= 1, 'Expected at least one HTML output file');
+      const html = fs.readFileSync(files[0], 'utf8');
+      // Core Unicode chars must survive the full pipeline
+      assert.match(html, /Héllo/, 'accented characters should be preserved');
+      assert.match(html, /日本語/, 'CJK characters should be preserved');
+      assert.match(html, /🦄/, 'emoji should be preserved');
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── ⑥ Resource marker text in --output-html ─────────────────────────────────
+
+describe('CLI (extra) — resource marker text in --output-html', () => {
+  test('[image not included] marker appears in output HTML when body has evernote+resource:// src', () => {
+    const cacheDir  = makeTempDir('marker-cache');
+    const outDir    = makeTempDir('marker-out');
+    const cwdDir    = makeTempDir('marker-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [{ key: 'm1', value: { title: 'Has Image', created: '2026-01-01T00:00:00Z' } }],
+        cacheRows: [{
+          key: 'm1',
+          value: '<p>before</p><img src="evernote+resource://abc-hash-123" alt="photo"/><p>after</p>',
+        }],
+      });
+      const { status, stdout } = run(
+        ['--from-local', '--cache-path', cacheFile, '--output-html', outDir],
+        { cwd: cwdDir },
+      );
+      assert.equal(status, 0, `non-zero exit; stdout:\n${stdout}`);
+      const files = findHtmlFiles(outDir);
+      assert.ok(files.length >= 1);
+      const html = fs.readFileSync(files[0], 'utf8');
+      assert.match(html, /image not included/i, 'resource marker text should be present in HTML output');
+      assert.doesNotMatch(html, /evernote\+resource/, 'raw resource URL must not appear in output HTML');
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('[attachment not included] marker appears for evernote+resource:// anchor links', () => {
+    const cacheDir  = makeTempDir('attach-cache');
+    const outDir    = makeTempDir('attach-out');
+    const cwdDir    = makeTempDir('attach-cwd');
+    const cacheFile = path.join(cacheDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      seedCacheFile(cacheFile, {
+        notes: [{ key: 'a1', value: { title: 'Has Attachment', created: '2026-01-01T00:00:00Z' } }],
+        cacheRows: [{
+          key: 'a1',
+          value: '<p>see <a href="evernote+resource://doc-hash">document.pdf</a> here</p>',
+        }],
+      });
+      run(['--from-local', '--cache-path', cacheFile, '--output-html', outDir], { cwd: cwdDir });
+      const files = findHtmlFiles(outDir);
+      assert.ok(files.length >= 1);
+      const html = fs.readFileSync(files[0], 'utf8');
+      assert.match(html, /attachment not included/i);
+      assert.doesNotMatch(html, /evernote\+resource/);
+    } finally {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+      fs.rmSync(outDir,   { recursive: true, force: true });
+      fs.rmSync(cwdDir,   { recursive: true, force: true });
+    }
+  });
+
+  test('file:// image src is scrubbed and produces marker in output HTML', () => {
+    const html = '<p>x</p><img src="file:///C:/Users/john/AppData/evernote/res/abc.png" />';
+    const scrubbed = scrubLocalResourceRefs(html);
+    assert.match(scrubbed, /image not included/i);
+    assert.doesNotMatch(scrubbed, /file:\/\//);
+  });
+});

--- a/tests/local-cache-reader.test.js
+++ b/tests/local-cache-reader.test.js
@@ -1,0 +1,286 @@
+'use strict';
+/**
+ * Local-cache reader tests — seed an in-memory SQLite to mimic
+ * Evernote v10/v11 conduit storage, exercise the reader, and assert
+ * that the produced notes look identical to enex-parser output.
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Database = require('better-sqlite3');
+const {
+  iterateNotes,
+  summarizeCache,
+  scrubLocalResourceRefs,
+  ensureEnexDate,
+  detectSchema,
+  discoverCacheFile,
+  openReadOnly,
+  LOCAL_FILENAME_SLOT,
+} = require('../src/local-cache-reader');
+
+function seedCache(db, { notes = [], tags = [], cacheRows = [] } = {}) {
+  db.exec(`
+    CREATE TABLE Nodes_Note  (TKey TEXT PRIMARY KEY, TValue TEXT);
+    CREATE TABLE Nodes_Tag   (TKey TEXT PRIMARY KEY, TValue TEXT);
+    CREATE TABLE CacheLookaside (TKey TEXT PRIMARY KEY, TValue TEXT);
+  `);
+  const insN = db.prepare('INSERT INTO Nodes_Note (TKey, TValue) VALUES (?, ?)');
+  const insT = db.prepare('INSERT INTO Nodes_Tag  (TKey, TValue) VALUES (?, ?)');
+  const insC = db.prepare('INSERT INTO CacheLookaside (TKey, TValue) VALUES (?, ?)');
+  for (const n of notes) insN.run(n.key, JSON.stringify(n.value));
+  for (const t of tags) insT.run(t.key, JSON.stringify(t.value));
+  for (const c of cacheRows) insC.run(c.key, c.value);
+}
+
+describe('local-cache-reader — iterateNotes', () => {
+  test('yields notes in enex-parser shape, body wrapped in <en-note>', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [
+        {
+          key: 'guid-1',
+          value: {
+            title: 'My first note',
+            created: '2026-01-15T09:30:00Z',
+            updated: '2026-01-16T10:00:00Z',
+            tagGuids: ['tag-a'],
+            author: 'John',
+            sourceUrl: 'https://example.com',
+          },
+        },
+      ],
+      tags: [{ key: 'tag-a', value: { name: 'work' } }],
+      cacheRows: [{ key: 'guid-1', value: '<p>Hello, world!</p>' }],
+    });
+
+    const out = [...iterateNotes(db)];
+    assert.equal(out.length, 1);
+    const n = out[0];
+    assert.equal(n.title, 'My first note');
+    assert.equal(n.created, '20260115T093000Z');
+    assert.equal(n.updated, '20260116T100000Z');
+    assert.deepEqual(n.tags, ['work']);
+    assert.equal(n.author, 'John');
+    assert.equal(n.sourceUrl, 'https://example.com');
+    assert.deepEqual(n.resources, []);
+    assert.match(n.content, /^<en-note><p>Hello, world!<\/p><\/en-note>$/);
+    db.close();
+  });
+
+  test('skips notes whose body has not been downloaded', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [
+        { key: 'has-body', value: { title: 'A', created: '2026-01-01T00:00:00Z' } },
+        { key: 'no-body',  value: { title: 'B', created: '2026-01-01T00:00:00Z' } },
+      ],
+      cacheRows: [{ key: 'has-body', value: '<p>body</p>' }],
+    });
+
+    const items = [...iterateNotes(db)];
+    const real = items.filter(i => !i._skip);
+    const skipped = items.filter(i => i._skip);
+    assert.equal(real.length, 1);
+    assert.equal(real[0].title, 'A');
+    assert.equal(skipped.length, 1);
+    assert.equal(skipped[0].reason, 'no-body');
+    assert.equal(skipped[0].guid, 'no-body');
+    db.close();
+  });
+
+  test('looks up body via "Note:<guid>" key variant', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'g42', value: { title: 'Prefixed body', created: '2026-02-01T12:00:00Z' } }],
+      cacheRows: [{ key: 'Note:g42', value: '<div>prefixed</div>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.match(out[0].content, /<en-note><div>prefixed<\/div><\/en-note>/);
+    db.close();
+  });
+
+  test('handles JSON-wrapped body envelopes ({html: …})', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'g1', value: { title: 'Wrapped', created: '2026-02-01T12:00:00Z' } }],
+      cacheRows: [{
+        key: 'g1',
+        value: JSON.stringify({ html: '<p>inside-json</p>', other: 'noise' }),
+      }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out.length, 1);
+    assert.match(out[0].content, /<p>inside-json<\/p>/);
+    db.close();
+  });
+
+  test('returns empty title fallback and empty tags array', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [{ key: 'g', value: { /* no title */ } }],
+      cacheRows: [{ key: 'g', value: '<p>x</p>' }],
+    });
+    const out = [...iterateNotes(db)].filter(n => !n._skip);
+    assert.equal(out[0].title, 'Untitled Note');
+    assert.deepEqual(out[0].tags, []);
+    db.close();
+  });
+
+  test('throws helpful error when Nodes_Note is missing', () => {
+    const db = new Database(':memory:');
+    db.exec('CREATE TABLE Whatever (x TEXT)');
+    assert.throws(() => [...iterateNotes(db)], /does not look like an Evernote cache/);
+    db.close();
+  });
+});
+
+describe('local-cache-reader — summarizeCache', () => {
+  test('counts total / withBody / withoutBody', () => {
+    const db = new Database(':memory:');
+    seedCache(db, {
+      notes: [
+        { key: 'a', value: { title: 'A' } },
+        { key: 'b', value: { title: 'B' } },
+        { key: 'c', value: { title: 'C' } },
+      ],
+      cacheRows: [
+        { key: 'a', value: '<p>1</p>' },
+        { key: 'Note:b', value: '<p>2</p>' },
+        // c has no body
+      ],
+    });
+    const s = summarizeCache(db);
+    assert.equal(s.total, 3);
+    assert.equal(s.withBody, 2);
+    assert.equal(s.withoutBody, 1);
+    assert.equal(s.available, true);
+    db.close();
+  });
+
+  test('reports available=false when Nodes_Note is missing', () => {
+    const db = new Database(':memory:');
+    db.exec('CREATE TABLE Other (x TEXT)');
+    const s = summarizeCache(db);
+    assert.equal(s.available, false);
+    assert.equal(s.total, 0);
+    db.close();
+  });
+});
+
+describe('local-cache-reader — scrubLocalResourceRefs', () => {
+  test('replaces evernote+resource:// images with marker', () => {
+    const html = '<p>before <img src="evernote+resource://abc123" alt="x"/> after</p>';
+    const out = scrubLocalResourceRefs(html);
+    assert.match(out, /image not included/);
+    assert.doesNotMatch(out, /evernote\+resource/);
+  });
+
+  test('replaces file:// images and absolute Windows paths', () => {
+    const out1 = scrubLocalResourceRefs('<img src="file:///C:/x.png"/>');
+    const out2 = scrubLocalResourceRefs('<img src="C:\\Users\\a\\b.png"/>');
+    assert.match(out1, /image not included/);
+    assert.match(out2, /image not included/);
+  });
+
+  test('replaces evernote+resource:// anchor attachments', () => {
+    const html = '<a href="evernote+resource://r1">file.pdf</a>';
+    const out = scrubLocalResourceRefs(html);
+    assert.match(out, /attachment not included/);
+  });
+
+  test('leaves regular http(s) images alone', () => {
+    const html = '<img src="https://example.com/p.png"/>';
+    const out = scrubLocalResourceRefs(html);
+    assert.equal(out, html);
+  });
+
+  test('handles empty / null input', () => {
+    assert.equal(scrubLocalResourceRefs(''), '');
+    assert.equal(scrubLocalResourceRefs(null), '');
+  });
+});
+
+describe('local-cache-reader — ensureEnexDate', () => {
+  test('passes ENEX-format dates through unchanged', () => {
+    assert.equal(ensureEnexDate('20260101T093000Z'), '20260101T093000Z');
+  });
+
+  test('converts ISO-8601 to ENEX format', () => {
+    assert.equal(ensureEnexDate('2026-01-01T09:30:00Z'), '20260101T093000Z');
+  });
+
+  test('converts numeric epoch ms to ENEX format', () => {
+    // 2026-03-15T10:20:30Z
+    const ms = Date.UTC(2026, 2, 15, 10, 20, 30);
+    assert.equal(ensureEnexDate(ms), '20260315T102030Z');
+  });
+
+  test('returns null for unparseable strings', () => {
+    assert.equal(ensureEnexDate('not a date'), null);
+    assert.equal(ensureEnexDate(null), null);
+    assert.equal(ensureEnexDate(undefined), null);
+  });
+});
+
+describe('local-cache-reader — detectSchema', () => {
+  test('identifies expected Evernote tables', () => {
+    const db = new Database(':memory:');
+    seedCache(db);
+    const s = detectSchema(db);
+    assert.equal(s.hasNodesNote, true);
+    assert.equal(s.hasNodesTag, true);
+    assert.equal(s.hasCacheLookaside, true);
+    assert.equal(s.hasNodesNotebook, false);
+    db.close();
+  });
+});
+
+describe('local-cache-reader — file IO', () => {
+  test('discoverCacheFile + openReadOnly: round-trip on a temp file', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'enote-cache-'));
+    const file = path.join(tmpDir, 'UDB-User1+RemoteGraph.sql');
+    try {
+      // Build a real on-disk DB with the expected shape.
+      const db = new Database(file);
+      seedCache(db, {
+        notes: [{ key: 'g1', value: { title: 'On-disk', created: '2026-01-01T00:00:00Z' } }],
+        cacheRows: [{ key: 'g1', value: '<p>disk</p>' }],
+      });
+      db.close();
+
+      // Discover by directory pointing at the dir
+      const discovered = discoverCacheFile({ explicitPath: tmpDir });
+      assert.equal(discovered, file);
+
+      // Open read-only and iterate
+      const ro = openReadOnly(file);
+      try {
+        const out = [...iterateNotes(ro)].filter(n => !n._skip);
+        assert.equal(out.length, 1);
+        assert.equal(out[0].title, 'On-disk');
+      } finally {
+        ro.close();
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('discoverCacheFile throws when explicit path does not exist', () => {
+    assert.throws(
+      () => discoverCacheFile({ explicitPath: path.join(os.tmpdir(), 'definitely-not-here-zzz', 'x.sql') }),
+      /Cache path not found/,
+    );
+  });
+});
+
+describe('local-cache-reader — module surface', () => {
+  test('exports LOCAL_FILENAME_SLOT', () => {
+    assert.equal(LOCAL_FILENAME_SLOT, '__local__');
+  });
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `--from-local` flag that imports notes by reading Evernote desktop's local conduit-storage SQLite cache directly. Eliminates the manual ENEX export step for users on a working Evernote v10/v11 install.

**Why now:** Evernote suspended new API key issuance on 2026-01-22 (no resolution after 3+ months). Without API access there was no path to skip the manual export step. The desktop client's local cache contains the full HTML body and bypasses the API entirely — no key, no OAuth, no rate limits, no ToS exposure.

## What's new

- `src/local-cache-reader.js` (NEW, 432 lines): path discovery, schema-detect, read-only SQLite open, note iterator that yields the same shape `enex-parser` produces
- `src/index.js`: `--from-local` / `--cache-path` flag parsing + mutual-exclusion against `--batch`
- `package.json`: `better-sqlite3` added to dependencies
- `README.md`: "Which mode should I use?" decision tree
- 59 new tests across 4 files (parser unit, CLI flag, round-trip integration, resumability)
- 556 / 0 fail / 7 skipped (was 497 / 0 / 7 — same passing baseline, +59 new)

## Reviewer follow-ups (already addressed in `f15f0c0`)

- macOS App Store (sandboxed) detection — `findSandboxedDarwinStore()` probes the container path and emits a specific error pointing users at Evernote Legacy
- `summarizeCache` perf — OR'd JOIN replaced with `UNION` of EXISTS subqueries (orders of magnitude faster on 10k+ note vaults)
- Scrubbed-resource counts surfaced in CLI dry-run summary

## Limitations (v1)

- Local cache only contains notes the user has opened in v10 or marked "Available offline" — partial caches surface a message instructing the user to enable offline mode and rerun
- Text-only: in-line images and attachments are replaced with `[image not included — export from Evernote for full content]` markers. Use `--batch` with ENEX for full fidelity
- Mac App Store (Core Data) variant is detected and refused; users on that build need Evernote Legacy or the direct download

## Test plan

- [ ] `npm test` green — 556 / 0 fail
- [ ] Dry-run on a real Evernote v10/v11 install: `evernote-to-onenote --from-local --dry-run`
- [ ] Resume after interrupt: `evernote-to-onenote --from-local`, Ctrl+C mid-import, rerun with `--resume`

🤖 Generated with [Claude Code](https://claude.com/claude-code)