### PR TITLE
fix(from-local): detect Evernote v11 + auto-detect cache subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,17 @@ There are two ways to read your notes — pick whichever applies:
 | Mode | When to use it | Command |
 |---|---|---|
 | **`--batch`** *(recommended)* | You can export `.enex` files from Evernote (File → Export → ENEX). Highest fidelity — includes images, attachments, and full formatting. | `evernote-to-onenote --batch ./Evernote-Export` |
-| **`--from-local`** | The Evernote API has been suspended on your account, you can't export `.enex`, and Evernote v10/v11 is installed on this computer. **Text-only:** images and attachments are not migrated. | `evernote-to-onenote --from-local` |
+| **`--from-local`** | You can't export `.enex` and **Evernote v10** is installed on this computer. **Text-only** — images and attachments are not migrated. **Does not support Evernote v11** (released 2026-01-19) — v11 doesn't keep the HTML body locally. | `evernote-to-onenote --from-local` |
 
 **Decision tree:**
 
-1. Can you click **File → Export Notes → ENEX format** in Evernote and get a `.enex` file? **Yes →** use `--batch`.
-2. Otherwise, is **Evernote v10 or v11** installed on this computer, and has it opened at least once while signed in? **Yes →** use `--from-local`.
-3. Otherwise — install Evernote v10/v11, sign in once, and let it sync. Then re-run with `--from-local`.
+1. Can you click **File → Export Notes → ENEX format** in Evernote and get a `.enex` file? **Yes →** use `--batch`. *(This is the only path that works on Evernote v11, the current desktop release.)*
+2. Otherwise, is **Evernote v10** installed on this computer, and has it opened at least once while signed in? **Yes →** use `--from-local`.
+3. Otherwise — fall back to `--batch`. v11 users must export to ENEX; the local-cache path doesn't have what we need.
 
 `--from-local` reads Evernote's local cache file in **read-only** mode — your Evernote data is not changed. Close Evernote completely before running it, or you may see a "database locked" error.
+
+**Why no v11 support:** Evernote v11 reworked the local cache. Note bodies are now stored as plain search-index text only; the HTML/ENML this importer needs is fetched on-demand from the server and not cached locally. `--from-local` detects v11 at runtime and refuses with a message pointing you at `--batch`.
 
 If you started with `--from-local` but later get your `.enex` export working, just run `--batch` — the importer will skip notes already imported (`progress.json` tracks both modes).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evernote-to-onenote",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evernote-to-onenote",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evernote-to-onenote",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Import Evernote .enex exports into Microsoft OneNote via the Graph API — resumable, scriptable, parallel",
   "license": "MIT",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -965,6 +965,22 @@ async function main() {
       try {
         const schema = detectSchema(db);
         const summary = summarizeCache(db, { schema });
+        // v1.4.1 — short-circuit on Evernote v11 flat-column schema. The
+        // body content available on v11 is plain text only (no HTML/ENML),
+        // so --from-local cannot produce a faithful import. Tell the
+        // operator clearly and stop before iterateLocalNotes throws.
+        if (summary.unsupportedSchema === 'v11-flat') {
+          console.error('  Evernote v11 desktop cache detected — --from-local does not support v11.');
+          console.error('  v11 only stores plain-text bodies locally; the HTML/ENML this importer');
+          console.error('  needs is fetched on-demand from Evernote\'s server and not cached on disk.');
+          console.error('  Use --batch with an ENEX export instead:');
+          console.error('    1. In Evernote: right-click a notebook → Export Notebook → ENEX format');
+          console.error('    2. Save .enex files to a folder (e.g. ./Evernote-Export)');
+          console.error('    3. Run: evernote-to-onenote --batch ./Evernote-Export');
+          totalFailed++;
+          try { db.close(); } catch { /* ignore */ }
+          continue;
+        }
         console.log(`  ${summary.total} note(s) found in local cache (${summary.withBody} have body text; ${summary.withoutBody} skipped — body not yet downloaded).`);
         if (summary.withoutBody > 0 && summary.withoutBody >= summary.withBody) {
           console.log('');

--- a/src/local-cache-reader.js
+++ b/src/local-cache-reader.js
@@ -86,20 +86,36 @@ function findSandboxedDarwinStore() {
   return null;
 }
 
-function findSqlInDir(dir) {
+function findSqlInDir(dir, depth = 2) {
+  // Recurse one level by default — conduit-storage on real installs has the
+  // SQL files inside a per-host subfolder (e.g. https%3A%2F%2Fwww.evernote.com)
+  // not at the top level. v1.4.0 shipped without recursion and silently
+  // failed auto-detect; this is the fix.
   let entries;
   try { entries = fs.readdirSync(dir); } catch { return null; }
   const matches = [];
+  const subdirs = [];
   for (const e of entries) {
     const full = path.join(dir, e);
     let stat;
     try { stat = fs.statSync(full); } catch { continue; }
-    if (!stat.isFile()) continue;
-    // Evernote v10/v11 typically writes:
-    //   UDB-User<id>+RemoteGraph.sql
-    // Match anything ending in RemoteGraph.sql — covers personal & business graphs.
-    if (/RemoteGraph\.sql$/i.test(e)) {
-      matches.push({ full, mtime: stat.mtimeMs });
+    if (stat.isFile()) {
+      // Evernote v10/v11 typically writes:
+      //   UDB-User<id>+RemoteGraph.sql
+      // Match anything ending in RemoteGraph.sql — covers personal & business graphs.
+      if (/RemoteGraph\.sql$/i.test(e)) {
+        matches.push({ full, mtime: stat.mtimeMs });
+      }
+    } else if (stat.isDirectory() && depth > 0) {
+      subdirs.push(full);
+    }
+  }
+  // Recurse only if no top-level matches; saves a stat() per file on the
+  // common --cache-path-points-at-the-folder-with-the-files case.
+  if (matches.length === 0) {
+    for (const sub of subdirs) {
+      const found = findSqlInDir(sub, depth - 1);
+      if (found) matches.push({ full: found, mtime: 0 });
     }
   }
   if (matches.length === 0) return null;
@@ -369,6 +385,29 @@ function* iterateNotes(db, { schema = null } = {}) {
   const noteCols = getColumnsOf(db, 'Nodes_Note');
   const idCol = pickColumn(noteCols, 'TKey', 'guid', 'id');
   const valCol = pickColumn(noteCols, 'TValue', 'value', 'data');
+
+  // Evernote v11 (released 2026-01-19) replaced the v10 TKey/TValue JSON-blob
+  // shape with flat columns (id, label, snippet, content_hash, created,
+  // updated, parent_Notebook_id, ...). The CacheLookaside body table was also
+  // dropped — bodies live in Offline_Search_Note_Content as plain text only,
+  // not the HTML/ENML this importer expects. Detect this layout up front and
+  // refuse with actionable guidance instead of "no recognised id/value
+  // columns" which leaves the operator stuck.
+  const isV11FlatSchema = !valCol && noteCols.has('id') && noteCols.has('content_hash') && noteCols.has('snippet');
+  if (isV11FlatSchema) {
+    throw new Error(
+      'Detected Evernote v11 desktop cache (flat-column schema), which --from-local does not support.\n' +
+      '  v11 stores note metadata as flat columns and only plain-text bodies\n' +
+      '  in Offline_Search_Note_Content — the HTML/ENML this importer needs is\n' +
+      '  not stored locally on v11. Two options:\n' +
+      '    1. Export your notebooks as .enex from Evernote, then run:\n' +
+      '         evernote-to-onenote --batch <export-folder>\n' +
+      '    2. Install Evernote v10 (the previous desktop release) — its local\n' +
+      '       cache uses the older schema this importer can read.\n' +
+      '  Tracking issue: https://github.com/mooja77/evernote-to-onenote/issues'
+    );
+  }
+
   if (!idCol || !valCol) {
     throw new Error(
       'Unexpected Nodes_Note schema (no recognised id/value columns).\n' +
@@ -442,6 +481,15 @@ function summarizeCache(db, { schema = null } = {}) {
 
   const noteCols = getColumnsOf(db, 'Nodes_Note');
   const noteIdCol = pickColumn(noteCols, 'TKey', 'guid', 'id');
+  // Evernote v11 has flat columns (no TKey/TValue) and no CacheLookaside.
+  // Mark unsupported so the caller doesn't print misleading totals like
+  // "2073 of 2073 notes don't have content yet" when in fact zero are
+  // extractable. iterateNotes() throws a v11-specific error with guidance.
+  const isV11FlatSchema = !pickColumn(noteCols, 'TValue', 'value', 'data')
+    && noteCols.has('id') && noteCols.has('content_hash') && noteCols.has('snippet');
+  if (isV11FlatSchema) {
+    return { total: 0, withBody: 0, withoutBody: 0, available: false, unsupportedSchema: 'v11-flat' };
+  }
   if (!noteIdCol) return { total: 0, withBody: 0, withoutBody: 0, available: false };
 
   const total = db.prepare('SELECT COUNT(*) AS c FROM Nodes_Note').get().c;

--- a/tests/local-cache-reader.test.js
+++ b/tests/local-cache-reader.test.js
@@ -284,3 +284,56 @@ describe('local-cache-reader — module surface', () => {
     assert.equal(LOCAL_FILENAME_SLOT, '__local__');
   });
 });
+
+// v1.4.1 regression coverage — these are the two bugs that shipped in 1.4.0
+// and surfaced on the first real test against an actual Evernote v11 install.
+describe('local-cache-reader — v1.4.1 regressions', () => {
+  test('detects v11 flat-column schema and refuses with actionable error', () => {
+    const db = new Database(':memory:');
+    // Mimic v11 layout: flat columns, no TKey/TValue, no CacheLookaside.
+    db.exec(`
+      CREATE TABLE Nodes_Note (
+        id TEXT PRIMARY KEY,
+        label TEXT,
+        snippet TEXT,
+        content_hash TEXT,
+        content_size REAL,
+        created INTEGER,
+        updated INTEGER,
+        deleted INTEGER,
+        markedForOffline INTEGER,
+        parent_Notebook_id TEXT
+      );
+    `);
+    db.prepare(`INSERT INTO Nodes_Note (id, label, content_hash, snippet) VALUES ('a', 'A', 'h1', 's1')`).run();
+
+    let err;
+    try { for (const _ of iterateNotes(db)) { /* drain */ } }
+    catch (e) { err = e; }
+    assert.ok(err, 'iterateNotes should throw on v11 schema');
+    assert.match(err.message, /v11/i);
+    assert.match(err.message, /--batch/);
+
+    const summary = summarizeCache(db);
+    assert.equal(summary.unsupportedSchema, 'v11-flat');
+    assert.equal(summary.available, false);
+    db.close();
+  });
+
+  test('discoverCacheFile recurses one level into a per-host subfolder', () => {
+    // Real Evernote conduit-storage layout: top-level dir → per-host
+    // subfolder (https%3A%2F%2Fwww.evernote.com) → UDB-User<id>+RemoteGraph.sql
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'efl-recurse-'));
+    const subdir = path.join(tmpRoot, 'https%3A%2F%2Fwww.evernote.com');
+    fs.mkdirSync(subdir);
+    const sqlPath = path.join(subdir, 'UDB-User999+RemoteGraph.sql');
+    // Empty file — discover only checks the name pattern, doesn't open.
+    fs.writeFileSync(sqlPath, '');
+    try {
+      const found = discoverCacheFile({ explicitPath: tmpRoot });
+      assert.equal(found, sqlPath);
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

v1.4.0 shipped two bugs that surfaced on the first real test against an actual Evernote v11 install:

1. **Auto-detect didn't find the cache file.** `findSqlInDir()` only checked direct children of the `conduit-storage` directory, but real installs put SQL files one level deeper inside a per-host subfolder (`https%3A%2F%2Fwww.evernote.com`). Now recurses one level when nothing matches at the top.

2. **v11 flat-column schema produced cryptic errors.** Evernote v11 (released 2026-01-19) replaced the v10 `TKey`/`TValue` JSON-blob shape with flat columns and dropped `CacheLookaside` entirely. Bodies live in `Offline_Search_Note_Content` as plain text only — the HTML/ENML this importer needs is fetched on-demand and not cached locally. The reader now detects v11 and refuses with a clear message pointing users at `--batch <enex-folder>` instead of `Unexpected Nodes_Note schema (no recognised id/value columns)`.

The architect's pre-implementation BLOCKERS B1/B2 in plan #47 had explicitly called for live-install verification before coding. The probe never happened in v1.4.0 — this PR is the catch-up.

## What changes

- `src/local-cache-reader.js`: `findSqlInDir` recurses one level; `iterateNotes` and `summarizeCache` short-circuit on v11 flat schema with actionable messages
- `src/index.js`: surfaces v11 detection at the dry-run summary, before iterateNotes gets called
- `README.md`: "Which mode should I use?" decision tree explicitly flags v10-only support; brief "Why no v11 support" explanation
- `tests/local-cache-reader.test.js`: +2 regression tests (v11 detection + auto-detect recursion)

## Test plan

- [x] `npm test`: 558/0/7 (was 556 in v1.4.0; +2 regression tests)
- [x] Auto-detect against a real Evernote v11 install: now finds the SQL file and emits the v11 message
- [x] `--cache-path` pointed at v11 file: same v11 message, no cryptic schema error

🤖 Generated with [Claude Code](https://claude.com/claude-code)